### PR TITLE
implement DHCP support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ features = ["stm32h743", "rt"]
 [dependencies.smoltcp]
 git = "https://github.com/m-labs/smoltcp.git"
 rev = "1ada3da"
-features = ["proto-ipv4", "socket-tcp"]
+features = ["proto-ipv4", "proto-dhcpv4", "socket-tcp"]
 default-features = false
 
 [dependencies.cortex-m-rtfm]


### PR DESCRIPTION
The choice between DHCP and a static address is set by a compile-time flag
in anticipation of implementing runtime adjustable configuration (#29).

Closes #24