### PR TITLE
Fix TCP command interface rx buffer wrapping

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -852,7 +852,7 @@ impl Server {
                     self.discard = true;
                     self.data.clear();
                 } else if !self.discard && len > 0 {
-                    self.data.extend_from_slice(&buf[..len - 1]).unwrap();
+                    self.data.extend_from_slice(&buf[..len]).unwrap();
                 }
                 (len, found)
             }).unwrap();
@@ -862,7 +862,7 @@ impl Server {
                     json_reply(socket, &Response { code: 520, message: "command buffer overflow" });
                     self.data.clear();
                 } else {
-                    let r = from_slice::<T>(&self.data);
+                    let r = from_slice::<T>(&self.data[..self.data.len() - 1]);
                     self.data.clear();
                     match r {
                         Ok(res) => {


### PR DESCRIPTION
Previously, if a message spanned the end of the
receive ring buffer, the last byte in the buffer
would be missing from the to-be-decoded message,
leading to a parse error or panic.

With this commit, >3M commands were exchanged
over one socket without further issues.