### PR TITLE
setup TIM2 after interrupts enabled (fixes #55)

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -522,11 +522,19 @@ pub fn init() {
     let dbgmcu = dp.DBGMCU;
     dbgmcu.apb1lfz1.modify(|_, w| w.tim2().set_bit());
 
-    tim2_setup(&dp.TIM2);
-
     let i2c2 = dp.I2C2;
     i2c::setup(&rcc, &i2c2);
 
     eth::setup(&rcc, &dp.SYSCFG);
     eth::setup_pins(&dp.GPIOA, &dp.GPIOB, &dp.GPIOC, &dp.GPIOG);
+}
+
+// Called after interrupts are enabled
+pub fn late_init() {
+    let dp = unsafe{ pac::Peripherals::steal()};
+
+    // If the main sampling timer is setup before interrupts are enabled the
+    // first interrupt can be serviced late, leading to sampling halting
+    // for one or both channels
+    tim2_setup(&dp.TIM2);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,6 +130,8 @@ const APP: () = {
     fn idle(c: idle::Context) -> ! {
         let (MAC, DMA, MTL) = c.resources.ethernet_periph;
 
+        board::late_init();
+
         let hardware_addr = match eeprom::read_eui48(c.resources.i2c) {
             Err(_) => {
                 info!("Could not read EEPROM, using default MAC address");


### PR DESCRIPTION
If TIM2 is setup before interrupts are enabled, the first interrupt can be
serviced late, leading to the sampling of one or both channels halting