### PR TITLE
Feature/optional pounder

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -172,13 +172,23 @@ const APP: () = {
 
         timer: hal::timer::Timer<hal::stm32::TIM2>,
 
-        // Note: Do not rustfmt the following definition, as it appears to cause a bug in GDB that
-        // results in failing to set breakpoints at correct locations.
+        // Note: It appears that rustfmt generates a format that GDB cannot recognize, which
+        // results in GDB breakpoints being set improperly. To debug, redefine the following
+        // definition to:
+        //
+        // ```rust
+        // net_interface: net::iface::EthernetInterface<
+        //     'static,
+        //     'static,
+        //     'static,
+        //     ethernet::EthernetDMA<'static>>,
+        // ```
         net_interface: net::iface::EthernetInterface<
             'static,
             'static,
             'static,
-            ethernet::EthernetDMA<'static>>,
+            ethernet::EthernetDMA<'static>,
+        >,
         eth_mac: ethernet::EthernetMAC,
         mac_addr: net::wire::EthernetAddress,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,6 +171,9 @@ const APP: () = {
         eeprom_i2c: hal::i2c::I2c<hal::stm32::I2C2>,
 
         timer: hal::timer::Timer<hal::stm32::TIM2>,
+
+        // Note: Do not rustfmt the following definition, as it appears to cause a bug in GDB that
+        // results in failing to set breakpoints at correct locations.
         net_interface: net::iface::EthernetInterface<
             'static,
             'static,
@@ -197,8 +200,7 @@ const APP: () = {
 
         let rcc = dp.RCC.constrain();
         let mut clocks = rcc
-            //TODO: Re-enable HSE for Stabilizer platform.
-            //            .use_hse(8.mhz())
+            .use_hse(8.mhz())
             .sysclk(400.mhz())
             .hclk(200.mhz())
             .per_ck(100.mhz())

--- a/src/pounder/mod.rs
+++ b/src/pounder/mod.rs
@@ -29,6 +29,7 @@ pub enum Error {
     InvalidAddress,
     InvalidChannel,
     Adc,
+    Access,
 }
 
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
This PR updates the initialization function to measure the PGOOD output on pounder to detect whether or not pounder is installed.

This also re-enables the high-speed external oscillator for Stabilizer.

**Note**: No timing was conducted on firmware and power-supply management for monitoring PGOOD. It is currently assumed that PGOOD is steady-state before the firmware measures it.