### PR TITLE
Cargo.toml: fix stm32h7xx-hal override

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,9 +58,10 @@ branch = "master"
 features = ["stm32h743v"]
 
 [dependencies.stm32h7xx-hal]
-git = "https://github.com/quartiq/stm32h7xx-hal.git"
-branch = "feature/pounder-support"
 features = ["stm32h743v", "rt", "unproven"]
+
+[patch.crates-io]
+stm32h7xx-hal = { git = "https://github.com/quartiq/stm32h7xx-hal.git", branch = "feature/pounder-support" }
 
 [features]
 semihosting = ["panic-semihosting", "cortex-m-log/semihosting"]


### PR DESCRIPTION
Doing it via dependencies.stm32h7xx-hal causes cargo vendor to fail with:

error: failed to sync

Caused by:
  found duplicate version of package `stm32h7xx-hal v0.5.0` vendored from two sources:

        source 1: registry `https://github.com/rust-lang/crates.io-index`
        source 2: https://github.com/quartiq/stm32h7xx-hal.git?branch=feature/pounder-support#ff00e938