### PR TITLE
Make stabilizer.py work on v0.4.0+

### DIFF
--- a/stabilizer.py
+++ b/stabilizer.py
@@ -17,11 +17,16 @@ class StabilizerConfig:
         self.reader, self.writer = await asyncio.open_connection(host, port)
 
     async def set(self, channel, iir):
-        up = OD([("channel", channel), ("iir", iir.as_dict())])
-        s = json.dumps(up, separators=(",", ":"))
+        value = OD([("channel", channel), ("iir", iir.as_dict())])
+        request = {
+            "req": "Write",
+            "attribute": "stabilizer/iir{}/state".format(channel),
+            "value": json.dumps(value, separators=[',', ':']).replace('"', "'"),
+        }
+        s = json.dumps(request, separators=[',', ':'])
         assert "\n" not in s
         logger.debug("send %s", s)
-        self.writer.write(s.encode() + b"\n")
+        self.writer.write(s.encode("ascii") + b"\n")
         r = (await self.reader.readline()).decode()
         logger.debug("recv %s", r)
         ret = json.loads(r, object_pairs_hook=OD)


### PR DESCRIPTION
This is a "dirty" fix to have `stabilizer.py` working with the new API since v0.4.0, by applying the new JSON format for the IIRs as follows:

```json
{
    "req": "Write",
    "attribute": "stabilizer/iir?/state",
    "value": {
        "channel":1,
        "iir":{
            "ba":[b0,b1,b2,a1,a2],
            "y_offset":?,
            "y_min":?,
            "y_max":?
         }
    }
}
```

The actual ASCII data sent will convert the innermost `"` to `'`, then wrap the curly-bracketed tree of `value` with `"`.
