### PR TITLE
Revert rtic from 0.5.5 to 0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rtic"
-version = "0.5.5"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30efcb6b7920d9016182c485687f0012487032a14c415d2fce6e9862ef8260e"
+checksum = "04cd388b154c7e7d212c5af7541ee1f174f29ccb0c22e9117f8d13a5aad233b6"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rtic-macros"
-version = "0.5.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1a6a4c9550373038c0e21a78d44d529bd697c25bbf6b8004bddc6e63b119c7"
+checksum = "29e29e01b3ec80d59bfd96aaf94d04008bebfde3ab7016e12bfbd6c0b466d22a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ panic-halt = "0.2"
 serde = { version = "1.0", features = ["derive"], default-features = false }
 heapless = { version = "0.5", features = ["serde"] }
 serde-json-core = "0.1"
-cortex-m-rtic = "0.5.5"
+cortex-m-rtic = "0.5.3"
 embedded-hal = "0.2.4"
 nb = "1.0.0"
 asm-delay = "0.9.0"

--- a/cargosha256.nix
+++ b/cargosha256.nix
@@ -1,1 +1,1 @@
-"0jcv24g9wliz4jbran3ak3ifnckxlwv9biprnhp7pi8gbza2c2sm"
+"0a16g7ys6jvnkcyx454ig3l713y89b8ymy0mgfdd973jbvjs9mjv"


### PR DESCRIPTION
This is to fix a panicking upon initialization problem that can be resolved by reverting the update earlier taken on the rtic crate.

Since d5916c550177ba6c3483f31a95b74b01f4a7ee9a where rtic is bumped from 0.5.3 to 0.5.5, the compiled firmware will cause the Stabilizer panick upon powering up. With GDB, the backtrace looks like this:
```
(gdb) backtrace
#0  0x08020c90 in rust_begin_unwind (_info=<optimized out>)
#1  0x08017532 in core::panicking::panic_fmt () at library/core/src/panicking.rs:85
#2  0x0801f0d0 in core::option::expect_failed () at library/core/src/option.rs:1213
#3  0x08014674 in stabilizer::init (c=...)
    at /rustc/6af1bdda54abc9e919fc1137411dfc4311e05649/library/core/src/option.rs:370
#4  0x0801741c in stabilizer::APP::main () at src/main.rs:160
```

Doing `next` on GDB from the first PC will put the CPU to the panicking loop after the following code:
```
...
halted: PC: 0x08000334
537	                *SCB_CPACR | SCB_CPACR_FPU_ENABLE | SCB_CPACR_FPU_USER,
(gdb) n
Info : halted: PC: 0x08000336
halted: PC: 0x08000336
Info : halted: PC: 0x0800033a
halted: PC: 0x0800033a
535	            core::ptr::write_volatile(
(gdb) n
Info : halted: PC: 0x0800033c
halted: PC: 0x0800033c
550	            trampoline()
(gdb) n
Info : halted: PC: 0x08020c88
halted: PC: 0x08020c88
^C
Program received signal SIGINT, Interrupt.
0x08020c96 in rust_begin_unwind (_info=<optimized out>)
```

On a side note, a similar symptom where the Ethernet PHY does not get reset, as discussed in #141, might have also arisen from this new version of rtic. However, the reset delay still seems a bit too short to me.