### PR TITLE
Fix syntax for taking core peripherals (required by cortex-m-rtic v0.5.5)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -203,7 +203,7 @@ const APP: () = {
     #[init]
     fn init(c: init::Context) -> init::LateResources {
         let dp = c.device;
-        let mut cp = cortex_m::Peripherals::take().unwrap();
+        let mut cp = c.core;
 
         let pwr = dp.PWR.constrain();
         let vos = pwr.freeze();


### PR DESCRIPTION
This is to fix a panicking upon initialization problem that is caused by a now undefined behaviour in our code from the perspective of the latest release of the cortex-m-rtic crate. 

As per conversation in https://github.com/rtic-rs/cortex-m-rtic/issues/361, `context.core` should now be used instead of `cortex_m::Peripherals::take()`, which would cause some unexpected behaviour.

On a side note, a similar symptom where the Ethernet PHY does not get reset, as discussed in #141, might have also arisen from this new version of rtic. However, the reset delay still seems a bit too short to me.