### PR TITLE
Fix server crashing & stabilizer.py hanging upon JSON reply

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -757,9 +757,7 @@ const APP: () = {
             {
                 let socket =
                     &mut *sockets.get::<net::socket::TcpSocket>(tcp_handle);
-                if socket.state() == net::socket::TcpState::CloseWait {
-                    socket.close();
-                } else if !(socket.is_open() || socket.is_listening()) {
+                if !socket.is_active() {
                     socket
                         .listen(1235)
                         .unwrap_or_else(|e| warn!("TCP listen error: {:?}", e));

--- a/stabilizer.py
+++ b/stabilizer.py
@@ -27,6 +27,7 @@ class StabilizerConfig:
         assert "\n" not in s
         logger.debug("send %s", s)
         self.writer.write(s.encode("ascii") + b"\n")
+        self.writer.write_eof()
         r = (await self.reader.readline()).decode()
         logger.debug("recv %s", r)
         ret = json.loads(r, object_pairs_hook=OD)


### PR DESCRIPTION
This is to fix the symptoms as described in #140, and shall act as an immediate remedy for current customers before MQTT gets implemented.

With my own experimentation, the client will not get back any replies from the server until it closes its transmission half, which is now done with the additional `write_eof()` call in `stabilizer.py`. 

In addition, if multiple valid JSON requests (or mixed with bytes in an unrecognized format), the server will respond with multiple replies accordingly. This can be tested with the [`socat`](https://linux.die.net/man/1/socat) tool and a plain text file containing lines of the JSON strings:

```shell
cat your_jsons.txt | socat stdio tcp4-connect:<stabilizer-ip>:1235
```