### PR TITLE
Feature/adc dac io macros

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -27,358 +27,184 @@ static mut SPI_START: [u16; 1] = [0x00];
 // The following global buffers are used for the ADC sample DMA transfers. Two buffers are used for
 // each transfer in a ping-pong buffer configuration (one is being acquired while the other is being
 // processed). Note that the contents of AXI SRAM is uninitialized, so the buffer contents on
-// startup are undefined.
+// startup are undefined. The dimension are `ADC_BUF[adc_index][ping_pong_index][sample_index]`.
 #[link_section = ".axisram.buffers"]
-static mut ADC0_BUF0: [u16; SAMPLE_BUFFER_SIZE] = [0; SAMPLE_BUFFER_SIZE];
+static mut ADC_BUF: [[[u16; SAMPLE_BUFFER_SIZE]; 2]; 2] =
+    [[[0; SAMPLE_BUFFER_SIZE]; 2]; 2];
 
-#[link_section = ".axisram.buffers"]
-static mut ADC0_BUF1: [u16; SAMPLE_BUFFER_SIZE] = [0; SAMPLE_BUFFER_SIZE];
-
-#[link_section = ".axisram.buffers"]
-static mut ADC1_BUF0: [u16; SAMPLE_BUFFER_SIZE] = [0; SAMPLE_BUFFER_SIZE];
-
-#[link_section = ".axisram.buffers"]
-static mut ADC1_BUF1: [u16; SAMPLE_BUFFER_SIZE] = [0; SAMPLE_BUFFER_SIZE];
-
-/// SPI2 is used as a ZST (zero-sized type) for indicating a DMA transfer into the SPI2 TX FIFO
-/// whenever the tim2 update dma request occurs.
-struct SPI2 {
-    _channel: sampling_timer::tim2::Channel1,
-}
-impl SPI2 {
-    pub fn new(_channel: sampling_timer::tim2::Channel1) -> Self {
-        Self { _channel }
-    }
-}
-
-// Note(unsafe): This structure is only safe to instantiate once. The DMA request is hard-coded and
-// may only be used if ownership of the timer2 channel 1 compare channel is assured, which is
-// ensured by maintaining ownership of the channel.
-unsafe impl TargetAddress<MemoryToPeripheral> for SPI2 {
-    /// SPI2 is configured to operate using 16-bit transfer words.
-    type MemSize = u16;
-
-    /// SPI2 DMA requests are generated whenever TIM2 CH1 comparison occurs.
-    const REQUEST_LINE: Option<u8> = Some(DMAReq::TIM2_CH1 as u8);
-
-    /// Whenever the DMA request occurs, it should write into SPI2's TX FIFO to start a DMA
-    /// transfer.
-    fn address(&self) -> u32 {
-        // Note(unsafe): It is assumed that SPI2 is owned by another DMA transfer and this DMA is
-        // only used for the transmit-half of DMA.
-        let regs = unsafe { &*hal::stm32::SPI2::ptr() };
-        &regs.txdr as *const _ as u32
-    }
-}
-
-/// SPI3 is used as a ZST (zero-sized type) for indicating a DMA transfer into the SPI3 TX FIFO
-/// whenever the tim2 update dma request occurs.
-struct SPI3 {
-    _channel: sampling_timer::tim2::Channel2,
-}
-impl SPI3 {
-    pub fn new(_channel: sampling_timer::tim2::Channel2) -> Self {
-        Self { _channel }
-    }
-}
-
-// Note(unsafe): This structure is only safe to instantiate once. The DMA request is hard-coded and
-// may only be used if ownership of the timer2 channel 2 compare channel is assured, which is
-// ensured by maintaining ownership of the channel.
-unsafe impl TargetAddress<MemoryToPeripheral> for SPI3 {
-    /// SPI3 is configured to operate using 16-bit transfer words.
-    type MemSize = u16;
-
-    /// SPI3 DMA requests are generated whenever TIM2 CH2 comparison occurs.
-    const REQUEST_LINE: Option<u8> = Some(DMAReq::TIM2_CH2 as u8);
-
-    /// Whenever the DMA request occurs, it should write into SPI3's TX FIFO to start a DMA
-    /// transfer.
-    fn address(&self) -> u32 {
-        // Note(unsafe): It is assumed that SPI3 is owned by another DMA transfer and this DMA is
-        // only used for the transmit-half of DMA.
-        let regs = unsafe { &*hal::stm32::SPI3::ptr() };
-        &regs.txdr as *const _ as u32
-    }
-}
-
-/// Represents both ADC input channels.
-pub struct AdcInputs {
-    adc0: Adc0Input,
-    adc1: Adc1Input,
-}
-
-impl AdcInputs {
-    /// Construct the ADC inputs.
-    pub fn new(adc0: Adc0Input, adc1: Adc1Input) -> Self {
-        Self { adc0, adc1 }
-    }
-
-    /// Interrupt handler to handle when the sample collection DMA transfer completes.
-    ///
-    /// # Returns
-    /// (adc0, adc1) where adcN is a reference to the collected ADC samples. Two array references
-    /// are returned - one for each ADC sample stream.
-    pub fn transfer_complete_handler(
-        &mut self,
-    ) -> (&[u16; SAMPLE_BUFFER_SIZE], &[u16; SAMPLE_BUFFER_SIZE]) {
-        let adc0_buffer = self.adc0.transfer_complete_handler();
-        let adc1_buffer = self.adc1.transfer_complete_handler();
-        (adc0_buffer, adc1_buffer)
-    }
-}
-
-/// Represents data associated with ADC0.
-pub struct Adc0Input {
-    next_buffer: Option<&'static mut [u16; SAMPLE_BUFFER_SIZE]>,
-    transfer: Transfer<
-        hal::dma::dma::Stream1<hal::stm32::DMA1>,
-        hal::spi::Spi<hal::stm32::SPI2, hal::spi::Disabled, u16>,
-        PeripheralToMemory,
-        &'static mut [u16; SAMPLE_BUFFER_SIZE],
-    >,
-    _trigger_transfer: Transfer<
-        hal::dma::dma::Stream0<hal::stm32::DMA1>,
-        SPI2,
-        MemoryToPeripheral,
-        &'static mut [u16; 1],
-    >,
-}
-
-impl Adc0Input {
-    /// Construct the ADC0 input channel.
-    ///
-    /// # Args
-    /// * `spi` - The SPI interface used to communicate with the ADC.
-    /// * `trigger_stream` - The DMA stream used to trigger each ADC transfer by writing a word into
-    ///   the SPI TX FIFO.
-    /// * `data_stream` - The DMA stream used to read samples received over SPI into a data buffer.
-    /// * `_trigger_channel` - The ADC sampling timer output compare channel for read triggers.
-    pub fn new(
-        spi: hal::spi::Spi<hal::stm32::SPI2, hal::spi::Enabled, u16>,
-        trigger_stream: hal::dma::dma::Stream0<hal::stm32::DMA1>,
-        data_stream: hal::dma::dma::Stream1<hal::stm32::DMA1>,
-        trigger_channel: sampling_timer::tim2::Channel1,
-    ) -> Self {
-        // Generate DMA events when an output compare of the timer hitting zero (timer roll over)
-        // occurs.
-        trigger_channel.listen_dma();
-        trigger_channel.to_output_compare(0);
-
-        // The trigger stream constantly writes to the TX FIFO using a static word (dont-care
-        // contents). Thus, neither the memory or peripheral address ever change. This is run in
-        // circular mode to be completed at every DMA request.
-        let trigger_config = DmaConfig::default()
-            .priority(Priority::High)
-            .circular_buffer(true);
-
-        // Construct the trigger stream to write from memory to the peripheral.
-        let mut trigger_transfer: Transfer<_, _, MemoryToPeripheral, _> =
-            Transfer::init(
-                trigger_stream,
-                SPI2::new(trigger_channel),
-                // Note(unsafe): Because this is a Memory->Peripheral transfer, this data is never
-                // actually modified. It technically only needs to be immutably borrowed, but the
-                // current HAL API only supports mutable borrows.
-                unsafe { &mut SPI_START },
-                None,
-                trigger_config,
-            );
-
-        // The data stream constantly reads from the SPI RX FIFO into a RAM buffer. The peripheral
-        // stalls reads of the SPI RX FIFO until data is available, so the DMA transfer completes
-        // after the requested number of samples have been collected. Note that only ADC1's data
-        // stream is used to trigger a transfer completion interrupt.
-        let data_config = DmaConfig::default()
-            .memory_increment(true)
-            .priority(Priority::VeryHigh);
-
-        // A SPI peripheral error interrupt is used to determine if the RX FIFO overflows. This
-        // indicates that samples were dropped due to excessive processing time in the main
-        // application (e.g. a second DMA transfer completes before the first was done with
-        // processing). This is used as a flow control indicator to guarantee that no ADC samples
-        // are lost.
-        let mut spi = spi.disable();
-        spi.listen(hal::spi::Event::Error);
-
-        // The data transfer is always a transfer of data from the peripheral to a RAM buffer.
-        let mut data_transfer: Transfer<_, _, PeripheralToMemory, _> =
-            Transfer::init(
-                data_stream,
-                spi,
-                // Note(unsafe): The ADC0_BUF0 is "owned" by this peripheral. It shall not be used
-                // anywhere else in the module.
-                unsafe { &mut ADC0_BUF0 },
-                None,
-                data_config,
-            );
-
-        data_transfer.start(|spi| {
-            // Allow the SPI FIFOs to operate using only DMA data channels.
-            spi.enable_dma_rx();
-            spi.enable_dma_tx();
-
-            // Enable SPI and start it in infinite transaction mode.
-            spi.inner().cr1.modify(|_, w| w.spe().set_bit());
-            spi.inner().cr1.modify(|_, w| w.cstart().started());
-        });
-
-        trigger_transfer.start(|_| {});
-
-        Self {
-            // Note(unsafe): The ADC0_BUF1 is "owned" by this peripheral. It shall not be used
-            // anywhere else in the module.
-            next_buffer: unsafe { Some(&mut ADC0_BUF1) },
-            transfer: data_transfer,
-            _trigger_transfer: trigger_transfer,
+macro_rules! adc_input {
+    ($name:ident, $index:literal, $trigger_stream:ident, $data_stream:ident,
+     $spi:ident, $trigger_channel:ident, $dma_req:ident) => {
+        /// SPI is used as a ZST (zero-sized type) for indicating a DMA transfer into the SPI TX FIFO
+        /// whenever the tim2 update dma request occurs.
+        struct $spi {
+            _channel: sampling_timer::tim2::$trigger_channel,
         }
-    }
-
-    /// Handle a transfer completion.
-    ///
-    /// # Returns
-    /// A reference to the underlying buffer that has been filled with ADC samples.
-    pub fn transfer_complete_handler(&mut self) -> &[u16; SAMPLE_BUFFER_SIZE] {
-        let next_buffer = self.next_buffer.take().unwrap();
-
-        // Wait for the transfer to fully complete before continuing.
-        // Note: If a device hangs up, check that this conditional is passing correctly, as there is
-        // no time-out checks here in the interest of execution speed.
-        while self.transfer.get_transfer_complete_flag() == false {}
-
-        // Start the next transfer.
-        self.transfer.clear_interrupts();
-        let (prev_buffer, _) =
-            self.transfer.next_transfer(next_buffer).unwrap();
-
-        self.next_buffer.replace(prev_buffer);
-        self.next_buffer.as_ref().unwrap()
-    }
-}
-
-/// Represents the data input stream from ADC1
-pub struct Adc1Input {
-    next_buffer: Option<&'static mut [u16; SAMPLE_BUFFER_SIZE]>,
-    transfer: Transfer<
-        hal::dma::dma::Stream3<hal::stm32::DMA1>,
-        hal::spi::Spi<hal::stm32::SPI3, hal::spi::Disabled, u16>,
-        PeripheralToMemory,
-        &'static mut [u16; SAMPLE_BUFFER_SIZE],
-    >,
-    _trigger_transfer: Transfer<
-        hal::dma::dma::Stream2<hal::stm32::DMA1>,
-        SPI3,
-        MemoryToPeripheral,
-        &'static mut [u16; 1],
-    >,
-}
-
-impl Adc1Input {
-    /// Construct a new ADC1 input data stream.
-    ///
-    /// # Args
-    /// * `spi` - The SPI interface connected to ADC1.
-    /// * `trigger_stream` - The DMA stream used to trigger ADC conversions on the SPI interface.
-    /// * `data_stream` - The DMA stream used to read ADC samples from the SPI RX FIFO.
-    /// * `trigger_channel` - The ADC sampling timer output compare channel for read triggers.
-    pub fn new(
-        spi: hal::spi::Spi<hal::stm32::SPI3, hal::spi::Enabled, u16>,
-        trigger_stream: hal::dma::dma::Stream2<hal::stm32::DMA1>,
-        data_stream: hal::dma::dma::Stream3<hal::stm32::DMA1>,
-        trigger_channel: sampling_timer::tim2::Channel2,
-    ) -> Self {
-        // Generate DMA events when an output compare of the timer hitting zero (timer roll over)
-        // occurs.
-        trigger_channel.listen_dma();
-        trigger_channel.to_output_compare(0);
-
-        // The trigger stream constantly writes to the TX FIFO using a static word (dont-care
-        // contents). Thus, neither the memory or peripheral address ever change. This is run in
-        // circular mode to be completed at every DMA request.
-        let trigger_config = DmaConfig::default()
-            .priority(Priority::High)
-            .circular_buffer(true);
-
-        // Construct the trigger stream to write from memory to the peripheral.
-        let mut trigger_transfer: Transfer<_, _, MemoryToPeripheral, _> =
-            Transfer::init(
-                trigger_stream,
-                SPI3::new(trigger_channel),
-                // Note(unsafe). This transaction is read-only and SPI_START is a dont-care value,
-                // so it is always safe to share.
-                unsafe { &mut SPI_START },
-                None,
-                trigger_config,
-            );
-
-        // The data stream constantly reads from the SPI RX FIFO into a RAM buffer. The peripheral
-        // stalls reads of the SPI RX FIFO until data is available, so the DMA transfer completes
-        // after the requested number of samples have been collected. Note that only ADC1's data
-        // stream is used to trigger a transfer completion interrupt.
-        let data_config = DmaConfig::default()
-            .memory_increment(true)
-            .transfer_complete_interrupt(true)
-            .priority(Priority::VeryHigh);
-
-        // A SPI peripheral error interrupt is used to determine if the RX FIFO overflows. This
-        // indicates that samples were dropped due to excessive processing time in the main
-        // application (e.g. a second DMA transfer completes before the first was done with
-        // processing). This is used as a flow control indicator to guarantee that no ADC samples
-        // are lost.
-        let mut spi = spi.disable();
-        spi.listen(hal::spi::Event::Error);
-
-        // The data transfer is always a transfer of data from the peripheral to a RAM buffer.
-        let mut data_transfer: Transfer<_, _, PeripheralToMemory, _> =
-            Transfer::init(
-                data_stream,
-                spi,
-                // Note(unsafe): The ADC1_BUF0 is "owned" by this peripheral. It shall not be used
-                // anywhere else in the module.
-                unsafe { &mut ADC1_BUF0 },
-                None,
-                data_config,
-            );
-
-        data_transfer.start(|spi| {
-            // Allow the SPI FIFOs to operate using only DMA data channels.
-            spi.enable_dma_rx();
-            spi.enable_dma_tx();
-
-            // Enable SPI and start it in infinite transaction mode.
-            spi.inner().cr1.modify(|_, w| w.spe().set_bit());
-            spi.inner().cr1.modify(|_, w| w.cstart().started());
-        });
-
-        trigger_transfer.start(|_| {});
-
-        Self {
-            // Note(unsafe): The ADC1_BUF1 is "owned" by this peripheral. It shall not be used
-            // anywhere else in the module.
-            next_buffer: unsafe { Some(&mut ADC1_BUF1) },
-            transfer: data_transfer,
-            _trigger_transfer: trigger_transfer,
+        impl $spi {
+            pub fn new(
+                _channel: sampling_timer::tim2::$trigger_channel,
+            ) -> Self {
+                Self { _channel }
+            }
         }
-    }
 
-    /// Handle a transfer completion.
-    ///
-    /// # Returns
-    /// A reference to the underlying buffer that has been filled with ADC samples.
-    pub fn transfer_complete_handler(&mut self) -> &[u16; SAMPLE_BUFFER_SIZE] {
-        let next_buffer = self.next_buffer.take().unwrap();
+        // Note(unsafe): This structure is only safe to instantiate once. The DMA request is hard-coded and
+        // may only be used if ownership of the timer2 $trigger_channel compare channel is assured, which is
+        // ensured by maintaining ownership of the channel.
+        unsafe impl TargetAddress<MemoryToPeripheral> for $spi {
+            /// SPI is configured to operate using 16-bit transfer words.
+            type MemSize = u16;
 
-        // Wait for the transfer to fully complete before continuing.
-        // Note: If a device hangs up, check that this conditional is passing correctly, as there is
-        // no time-out checks here in the interest of execution speed.
-        while self.transfer.get_transfer_complete_flag() == false {}
+            /// SPI DMA requests are generated whenever TIM2 CH1 comparison occurs.
+            const REQUEST_LINE: Option<u8> = Some(DMAReq::$dma_req as u8);
 
-        // Start the next transfer.
-        self.transfer.clear_interrupts();
-        let (prev_buffer, _) =
-            self.transfer.next_transfer(next_buffer).unwrap();
+            /// Whenever the DMA request occurs, it should write into SPI's TX FIFO to start a DMA
+            /// transfer.
+            fn address(&self) -> u32 {
+                // Note(unsafe): It is assumed that SPI is owned by another DMA transfer and this DMA is
+                // only used for the transmit-half of DMA.
+                let regs = unsafe { &*hal::stm32::$spi::ptr() };
+                &regs.txdr as *const _ as u32
+            }
+        }
 
-        self.next_buffer.replace(prev_buffer);
-        self.next_buffer.as_ref().unwrap()
-    }
+        /// Represents data associated with ADC0.
+        pub struct $name {
+            next_buffer: Option<&'static mut [u16; SAMPLE_BUFFER_SIZE]>,
+            transfer: Transfer<
+                hal::dma::dma::$data_stream<hal::stm32::DMA1>,
+                hal::spi::Spi<hal::stm32::$spi, hal::spi::Disabled, u16>,
+                PeripheralToMemory,
+                &'static mut [u16; SAMPLE_BUFFER_SIZE],
+            >,
+            _trigger_transfer: Transfer<
+                hal::dma::dma::$trigger_stream<hal::stm32::DMA1>,
+                $spi,
+                MemoryToPeripheral,
+                &'static mut [u16; 1],
+            >,
+        }
+
+        impl $name {
+            /// Construct the ADC0 input channel.
+            ///
+            /// # Args
+            /// * `spi` - The SPI interface used to communicate with the ADC.
+            /// * `trigger_stream` - The DMA stream used to trigger each ADC transfer by writing a word into
+            ///   the SPI TX FIFO.
+            /// * `data_stream` - The DMA stream used to read samples received over SPI into a data buffer.
+            /// * `_trigger_channel` - The ADC sampling timer output compare channel for read triggers.
+            pub fn new(
+                spi: hal::spi::Spi<hal::stm32::$spi, hal::spi::Enabled, u16>,
+                trigger_stream: hal::dma::dma::$trigger_stream<
+                    hal::stm32::DMA1,
+                >,
+                data_stream: hal::dma::dma::$data_stream<hal::stm32::DMA1>,
+                trigger_channel: sampling_timer::tim2::$trigger_channel,
+            ) -> Self {
+                // Generate DMA events when an output compare of the timer hitting zero (timer roll over)
+                // occurs.
+                trigger_channel.listen_dma();
+                trigger_channel.to_output_compare(0);
+
+                // The trigger stream constantly writes to the TX FIFO using a static word (dont-care
+                // contents). Thus, neither the memory or peripheral address ever change. This is run in
+                // circular mode to be completed at every DMA request.
+                let trigger_config = DmaConfig::default()
+                    .priority(Priority::High)
+                    .circular_buffer(true);
+
+                // Construct the trigger stream to write from memory to the peripheral.
+                let mut trigger_transfer: Transfer<
+                    _,
+                    _,
+                    MemoryToPeripheral,
+                    _,
+                > = Transfer::init(
+                    trigger_stream,
+                    $spi::new(trigger_channel),
+                    // Note(unsafe): Because this is a Memory->Peripheral transfer, this data is never
+                    // actually modified. It technically only needs to be immutably borrowed, but the
+                    // current HAL API only supports mutable borrows.
+                    unsafe { &mut SPI_START },
+                    None,
+                    trigger_config,
+                );
+
+                // The data stream constantly reads from the SPI RX FIFO into a RAM buffer. The peripheral
+                // stalls reads of the SPI RX FIFO until data is available, so the DMA transfer completes
+                // after the requested number of samples have been collected. Note that only ADC1's (sic!)
+                // data stream is used to trigger a transfer completion interrupt.
+                let data_config = DmaConfig::default()
+                    .memory_increment(true)
+                    .priority(Priority::VeryHigh);
+
+                // A SPI peripheral error interrupt is used to determine if the RX FIFO overflows. This
+                // indicates that samples were dropped due to excessive processing time in the main
+                // application (e.g. a second DMA transfer completes before the first was done with
+                // processing). This is used as a flow control indicator to guarantee that no ADC samples
+                // are lost.
+                let mut spi = spi.disable();
+                spi.listen(hal::spi::Event::Error);
+
+                // The data transfer is always a transfer of data from the peripheral to a RAM buffer.
+                let mut data_transfer: Transfer<_, _, PeripheralToMemory, _> =
+                    Transfer::init(
+                        data_stream,
+                        spi,
+                        // Note(unsafe): The ADC_BUF[$index][0] is "owned" by this peripheral.
+                        // It shall not be used anywhere else in the module.
+                        unsafe { &mut ADC_BUF[$index][0] },
+                        None,
+                        data_config,
+                    );
+
+                data_transfer.start(|spi| {
+                    // Allow the SPI FIFOs to operate using only DMA data channels.
+                    spi.enable_dma_rx();
+                    spi.enable_dma_tx();
+
+                    // Enable SPI and start it in infinite transaction mode.
+                    spi.inner().cr1.modify(|_, w| w.spe().set_bit());
+                    spi.inner().cr1.modify(|_, w| w.cstart().started());
+                });
+
+                trigger_transfer.start(|_| {});
+
+                Self {
+                    // Note(unsafe): The ADC_BUF[$index][1] is "owned" by this peripheral. It shall not be used
+                    // anywhere else in the module.
+                    next_buffer: unsafe { Some(&mut ADC_BUF[$index][1]) },
+                    transfer: data_transfer,
+                    _trigger_transfer: trigger_transfer,
+                }
+            }
+
+            /// Handle a transfer completion.
+            ///
+            /// # Returns
+            /// A reference to the underlying buffer that has been filled with ADC samples.
+            pub fn transfer_complete_handler(
+                &mut self,
+            ) -> &[u16; SAMPLE_BUFFER_SIZE] {
+                let next_buffer = self.next_buffer.take().unwrap();
+
+                // Wait for the transfer to fully complete before continuing.
+                // Note: If a device hangs up, check that this conditional is passing correctly, as there is
+                // no time-out checks here in the interest of execution speed.
+                while self.transfer.get_transfer_complete_flag() == false {}
+
+                // Start the next transfer.
+                self.transfer.clear_interrupts();
+                let (prev_buffer, _) =
+                    self.transfer.next_transfer(next_buffer).unwrap();
+
+                self.next_buffer.replace(prev_buffer);
+                self.next_buffer.as_ref().unwrap()
+            }
+        }
+    };
 }
+
+adc_input!(Adc0Input, 0, Stream0, Stream1, SPI2, Channel1, TIM2_CH1);
+adc_input!(Adc1Input, 1, Stream2, Stream3, SPI3, Channel2, TIM2_CH2);

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -185,9 +185,7 @@ macro_rules! adc_input {
             ///
             /// # Returns
             /// A reference to the underlying buffer that has been filled with ADC samples.
-            pub fn acquire_buffer(
-                &mut self,
-            ) -> &'static mut [u16; SAMPLE_BUFFER_SIZE] {
+            pub fn acquire_buffer(&mut self) -> &[u16; SAMPLE_BUFFER_SIZE] {
                 // Wait for the transfer to fully complete before continuing.
                 // Note: If a device hangs up, check that this conditional is passing correctly, as there is
                 // no time-out checks here in the interest of execution speed.
@@ -200,18 +198,9 @@ macro_rules! adc_input {
                 let (prev_buffer, _) =
                     self.transfer.next_transfer(next_buffer).unwrap();
 
-                prev_buffer
-            }
+                self.next_buffer.replace(prev_buffer); // .unwrap_none() https://github.com/rust-lang/rust/issues/62633
 
-            /// Release a buffer of ADC samples to the pool.
-            ///
-            /// # Args
-            /// * `next_buffer` - Buffer of ADC samples to be re-used.
-            pub fn release_buffer(
-                &mut self,
-                next_buffer: &'static mut [u16; SAMPLE_BUFFER_SIZE],
-            ) {
-                self.next_buffer.replace(next_buffer); // .unwrap_none() https://github.com/rust-lang/rust/issues/62633
+                self.next_buffer.as_ref().unwrap()
             }
         }
     };

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -55,7 +55,7 @@ macro_rules! adc_input {
             /// SPI is configured to operate using 16-bit transfer words.
             type MemSize = u16;
 
-            /// SPI DMA requests are generated whenever TIM2 CH1 comparison occurs.
+            /// SPI DMA requests are generated whenever TIM2 CHx ($dma_req) comparison occurs.
             const REQUEST_LINE: Option<u8> = Some(DMAReq::$dma_req as u8);
 
             /// Whenever the DMA request occurs, it should write into SPI's TX FIFO to start a DMA

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -137,6 +137,7 @@ macro_rules! adc_input {
                 // data stream is used to trigger a transfer completion interrupt.
                 let data_config = DmaConfig::default()
                     .memory_increment(true)
+                    .transfer_complete_interrupt($index == 1)
                     .priority(Priority::VeryHigh);
 
                 // A SPI peripheral error interrupt is used to determine if the RX FIFO overflows. This

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -27,7 +27,7 @@ static mut SPI_START: [u16; 1] = [0x00];
 // The following global buffers are used for the ADC sample DMA transfers. Two buffers are used for
 // each transfer in a ping-pong buffer configuration (one is being acquired while the other is being
 // processed). Note that the contents of AXI SRAM is uninitialized, so the buffer contents on
-// startup are undefined. The dimension are `ADC_BUF[adc_index][ping_pong_index][sample_index]`.
+// startup are undefined. The dimensions are `ADC_BUF[adc_index][ping_pong_index][sample_index]`.
 #[link_section = ".axisram.buffers"]
 static mut ADC_BUF: [[[u16; SAMPLE_BUFFER_SIZE]; 2]; 2] =
     [[[0; SAMPLE_BUFFER_SIZE]; 2]; 2];
@@ -35,7 +35,7 @@ static mut ADC_BUF: [[[u16; SAMPLE_BUFFER_SIZE]; 2]; 2] =
 macro_rules! adc_input {
     ($name:ident, $index:literal, $trigger_stream:ident, $data_stream:ident,
      $spi:ident, $trigger_channel:ident, $dma_req:ident) => {
-        /// $spi is used as a ZST (zero-sized type) for indicating a DMA transfer into the SPI TX FIFO
+        /// $spi is used as a type for indicating a DMA transfer into the SPI TX FIFO
         /// whenever the tim2 update dma request occurs.
         struct $spi {
             _channel: sampling_timer::tim2::$trigger_channel,

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -35,7 +35,7 @@ static mut ADC_BUF: [[[u16; SAMPLE_BUFFER_SIZE]; 2]; 2] =
 macro_rules! adc_input {
     ($name:ident, $index:literal, $trigger_stream:ident, $data_stream:ident,
      $spi:ident, $trigger_channel:ident, $dma_req:ident) => {
-        /// SPI is used as a ZST (zero-sized type) for indicating a DMA transfer into the SPI TX FIFO
+        /// $spi is used as a ZST (zero-sized type) for indicating a DMA transfer into the SPI TX FIFO
         /// whenever the tim2 update dma request occurs.
         struct $spi {
             _channel: sampling_timer::tim2::$trigger_channel,
@@ -68,7 +68,7 @@ macro_rules! adc_input {
             }
         }
 
-        /// Represents data associated with ADC0.
+        /// Represents data associated with ADC.
         pub struct $name {
             next_buffer: Option<&'static mut [u16; SAMPLE_BUFFER_SIZE]>,
             transfer: Transfer<
@@ -86,7 +86,7 @@ macro_rules! adc_input {
         }
 
         impl $name {
-            /// Construct the ADC0 input channel.
+            /// Construct the ADC input channel.
             ///
             /// # Args
             /// * `spi` - The SPI interface used to communicate with the ADC.

--- a/src/dac.rs
+++ b/src/dac.rs
@@ -19,7 +19,7 @@ static mut DAC_BUF: [[[u16; SAMPLE_BUFFER_SIZE]; 2]; 2] =
 macro_rules! dac_output {
     ($name:ident, $index:literal, $data_stream:ident,
      $spi:ident, $trigger_channel:ident, $dma_req:ident) => {
-        /// SPI is used as a type for indicating a DMA transfer into the SPI TX FIFO
+        /// $spi is used as a type for indicating a DMA transfer into the SPI TX FIFO
         struct $spi {
             spi: hal::spi::Spi<hal::stm32::$spi, hal::spi::Disabled, u16>,
             _channel: sampling_timer::tim2::$trigger_channel,
@@ -50,7 +50,7 @@ macro_rules! dac_output {
             }
         }
 
-        /// Represents data associated with DAC0.
+        /// Represents data associated with DAC.
         pub struct $name {
             next_buffer: Option<&'static mut [u16; SAMPLE_BUFFER_SIZE]>,
             // Note: SPI TX functionality may not be used from this structure to ensure safety with DMA.

--- a/src/dac.rs
+++ b/src/dac.rs
@@ -41,7 +41,7 @@ macro_rules! dac_output {
             /// SPI is configured to operate using 16-bit transfer words.
             type MemSize = u16;
 
-            /// SPI DMA requests are generated whenever TIM2 CH3 comparison occurs.
+            /// SPI DMA requests are generated whenever TIM2 CHx ($dma_req) comparison occurs.
             const REQUEST_LINE: Option<u8> = Some(DMAReq::$dma_req as u8);
 
             /// Whenever the DMA request occurs, it should write into SPI's TX FIFO.

--- a/src/dac.rs
+++ b/src/dac.rs
@@ -11,7 +11,7 @@ use super::{
 // The following global buffers are used for the DAC code DMA transfers. Two buffers are used for
 // each transfer in a ping-pong buffer configuration (one is being prepared while the other is being
 // processed). Note that the contents of AXI SRAM is uninitialized, so the buffer contents on
-// startup are undefined. The dimension are `ADC_BUF[adc_index][ping_pong_index][sample_index]`.
+// startup are undefined. The dimensions are `ADC_BUF[adc_index][ping_pong_index][sample_index]`.
 #[link_section = ".axisram.buffers"]
 static mut DAC_BUF: [[[u16; SAMPLE_BUFFER_SIZE]; 2]; 2] =
     [[[0; SAMPLE_BUFFER_SIZE]; 2]; 2];

--- a/src/dac.rs
+++ b/src/dac.rs
@@ -11,306 +11,143 @@ use super::{
 // The following global buffers are used for the DAC code DMA transfers. Two buffers are used for
 // each transfer in a ping-pong buffer configuration (one is being prepared while the other is being
 // processed). Note that the contents of AXI SRAM is uninitialized, so the buffer contents on
-// startup are undefined.
+// startup are undefined. The dimension are `ADC_BUF[adc_index][ping_pong_index][sample_index]`.
 #[link_section = ".axisram.buffers"]
-static mut DAC0_BUF0: [u16; SAMPLE_BUFFER_SIZE] = [0; SAMPLE_BUFFER_SIZE];
+static mut DAC_BUF: [[[u16; SAMPLE_BUFFER_SIZE]; 2]; 2] =
+    [[[0; SAMPLE_BUFFER_SIZE]; 2]; 2];
 
-#[link_section = ".axisram.buffers"]
-static mut DAC0_BUF1: [u16; SAMPLE_BUFFER_SIZE] = [0; SAMPLE_BUFFER_SIZE];
-
-#[link_section = ".axisram.buffers"]
-static mut DAC1_BUF0: [u16; SAMPLE_BUFFER_SIZE] = [0; SAMPLE_BUFFER_SIZE];
-
-#[link_section = ".axisram.buffers"]
-static mut DAC1_BUF1: [u16; SAMPLE_BUFFER_SIZE] = [0; SAMPLE_BUFFER_SIZE];
-
-/// SPI4 is used as a type for indicating a DMA transfer into the SPI4 TX FIFO
-struct SPI4 {
-    spi: hal::spi::Spi<hal::stm32::SPI4, hal::spi::Disabled, u16>,
-    _channel: sampling_timer::tim2::Channel3,
-}
-
-impl SPI4 {
-    pub fn new(
-        _channel: sampling_timer::tim2::Channel3,
-        spi: hal::spi::Spi<hal::stm32::SPI4, hal::spi::Disabled, u16>,
-    ) -> Self {
-        Self { _channel, spi }
-    }
-}
-
-// Note(unsafe): This is safe because the DMA request line is logically owned by this module.
-// Additionally, the SPI is owned by this structure and is known to be configured for u16 word
-// sizes.
-unsafe impl TargetAddress<MemoryToPeripheral> for SPI4 {
-    /// SPI2 is configured to operate using 16-bit transfer words.
-    type MemSize = u16;
-
-    /// SPI4 DMA requests are generated whenever TIM2 CH3 comparison occurs.
-    const REQUEST_LINE: Option<u8> = Some(DMAReq::TIM2_CH3 as u8);
-
-    /// Whenever the DMA request occurs, it should write into SPI4's TX FIFO.
-    fn address(&self) -> u32 {
-        &self.spi.inner().txdr as *const _ as u32
-    }
-}
-
-/// SPI5 is used as a ZST (zero-sized type) for indicating a DMA transfer into the SPI5 TX FIFO
-struct SPI5 {
-    _channel: sampling_timer::tim2::Channel4,
-    spi: hal::spi::Spi<hal::stm32::SPI5, hal::spi::Disabled, u16>,
-}
-
-impl SPI5 {
-    pub fn new(
-        _channel: sampling_timer::tim2::Channel4,
-        spi: hal::spi::Spi<hal::stm32::SPI5, hal::spi::Disabled, u16>,
-    ) -> Self {
-        Self { _channel, spi }
-    }
-}
-
-// Note(unsafe): This is safe because the DMA request line is logically owned by this module.
-// Additionally, the SPI is owned by this structure and is known to be configured for u16 word
-// sizes.
-unsafe impl TargetAddress<MemoryToPeripheral> for SPI5 {
-    /// SPI5 is configured to operate using 16-bit transfer words.
-    type MemSize = u16;
-
-    /// SPI5 DMA requests are generated whenever TIM2 CH4 comparison occurs.
-    const REQUEST_LINE: Option<u8> = Some(DMAReq::TIM2_CH4 as u8);
-
-    /// Whenever the DMA request occurs, it should write into SPI5's TX FIFO
-    fn address(&self) -> u32 {
-        &self.spi.inner().txdr as *const _ as u32
-    }
-}
-
-/// Represents both DAC output channels.
-pub struct DacOutputs {
-    dac0: Dac0Output,
-    dac1: Dac1Output,
-}
-
-impl DacOutputs {
-    /// Construct the DAC outputs.
-    pub fn new(dac0: Dac0Output, dac1: Dac1Output) -> Self {
-        Self { dac0, dac1 }
-    }
-
-    /// Borrow the next DAC output buffers to populate the DAC output codes in-place.
-    ///
-    /// # Returns
-    /// (dac0, dac1) where each value is a mutable reference to the output code array for DAC0 and
-    /// DAC1 respectively.
-    pub fn prepare_data(
-        &mut self,
-    ) -> (
-        &mut [u16; SAMPLE_BUFFER_SIZE],
-        &mut [u16; SAMPLE_BUFFER_SIZE],
-    ) {
-        (self.dac0.prepare_buffer(), self.dac1.prepare_buffer())
-    }
-
-    /// Enqueue the next DAC output codes for transmission.
-    ///
-    /// # Note
-    /// It is assumed that data was populated using `prepare_data()` before this function is
-    /// called.
-    pub fn commit_data(&mut self) {
-        self.dac0.commit_buffer();
-        self.dac1.commit_buffer();
-    }
-}
-
-/// Represents data associated with DAC0.
-pub struct Dac0Output {
-    next_buffer: Option<&'static mut [u16; SAMPLE_BUFFER_SIZE]>,
-    // Note: SPI TX functionality may not be used from this structure to ensure safety with DMA.
-    transfer: Transfer<
-        hal::dma::dma::Stream4<hal::stm32::DMA1>,
-        SPI4,
-        MemoryToPeripheral,
-        &'static mut [u16; SAMPLE_BUFFER_SIZE],
-    >,
-    first_transfer: bool,
-}
-
-impl Dac0Output {
-    /// Construct the DAC0 output channel.
-    ///
-    /// # Args
-    /// * `spi` - The SPI interface used to communicate with the ADC.
-    /// * `stream` - The DMA stream used to write DAC codes over SPI.
-    /// * `trigger_channel` - The sampling timer output compare channel for update triggers.
-    pub fn new(
-        spi: hal::spi::Spi<hal::stm32::SPI4, hal::spi::Enabled, u16>,
-        stream: hal::dma::dma::Stream4<hal::stm32::DMA1>,
-        trigger_channel: sampling_timer::tim2::Channel3,
-    ) -> Self {
-        // Generate DMA events when an output compare of the timer hitting zero (timer roll over)
-        // occurs.
-        trigger_channel.listen_dma();
-        trigger_channel.to_output_compare(0);
-
-        // The stream constantly writes to the TX FIFO to write new update codes.
-        let trigger_config = DmaConfig::default()
-            .memory_increment(true)
-            .peripheral_increment(false);
-
-        // Listen for any potential SPI error signals, which may indicate that we are not generating
-        // update codes.
-        let mut spi = spi.disable();
-        spi.listen(hal::spi::Event::Error);
-
-        // Allow the SPI FIFOs to operate using only DMA data channels.
-        spi.enable_dma_tx();
-
-        // Enable SPI and start it in infinite transaction mode.
-        spi.inner().cr1.modify(|_, w| w.spe().set_bit());
-        spi.inner().cr1.modify(|_, w| w.cstart().started());
-
-        // Construct the trigger stream to write from memory to the peripheral.
-        let transfer: Transfer<_, _, MemoryToPeripheral, _> = Transfer::init(
-            stream,
-            SPI4::new(trigger_channel, spi),
-            // Note(unsafe): This buffer is only used once and provided for the DMA transfer.
-            unsafe { &mut DAC0_BUF0 },
-            None,
-            trigger_config,
-        );
-
-        Self {
-            transfer,
-            // Note(unsafe): This buffer is only used once and provided for the next DMA transfer.
-            next_buffer: unsafe { Some(&mut DAC0_BUF1) },
-            first_transfer: true,
-        }
-    }
-
-    /// Mutably borrow the next output buffer to populate it with DAC codes.
-    pub fn prepare_buffer(&mut self) -> &mut [u16; SAMPLE_BUFFER_SIZE] {
-        self.next_buffer.as_mut().unwrap()
-    }
-
-    /// Enqueue the next buffer for transmission to the DAC.
-    ///
-    /// # Args
-    /// * `data` - The next data to write to the DAC.
-    pub fn commit_buffer(&mut self) {
-        let next_buffer = self.next_buffer.take().unwrap();
-
-        // If the last transfer was not complete, we didn't write all our previous DAC codes.
-        // Wait for all the DAC codes to get written as well.
-        if self.first_transfer {
-            self.first_transfer = false
-        } else {
-            // Note: If a device hangs up, check that this conditional is passing correctly, as
-            // there is no time-out checks here in the interest of execution speed.
-            while self.transfer.get_transfer_complete_flag() == false {}
+macro_rules! dac_output {
+    ($name:ident, $index:literal, $data_stream:ident,
+     $spi:ident, $trigger_channel:ident, $dma_req:ident) => {
+        /// SPI is used as a type for indicating a DMA transfer into the SPI TX FIFO
+        struct $spi {
+            spi: hal::spi::Spi<hal::stm32::$spi, hal::spi::Disabled, u16>,
+            _channel: sampling_timer::tim2::$trigger_channel,
         }
 
-        // Start the next transfer.
-        self.transfer.clear_interrupts();
-        let (prev_buffer, _) =
-            self.transfer.next_transfer(next_buffer).unwrap();
-
-        self.next_buffer.replace(prev_buffer);
-    }
-}
-
-/// Represents the data output stream from DAC1.
-pub struct Dac1Output {
-    next_buffer: Option<&'static mut [u16; SAMPLE_BUFFER_SIZE]>,
-    transfer: Transfer<
-        hal::dma::dma::Stream5<hal::stm32::DMA1>,
-        SPI5,
-        MemoryToPeripheral,
-        &'static mut [u16; SAMPLE_BUFFER_SIZE],
-    >,
-    first_transfer: bool,
-}
-
-impl Dac1Output {
-    /// Construct a new DAC1 output data stream.
-    ///
-    /// # Args
-    /// * `spi` - The SPI interface connected to DAC1.
-    /// * `stream` - The DMA stream used to write DAC codes the SPI TX FIFO.
-    /// * `trigger_channel` - The timer channel used to generate DMA requests for DAC updates.
-    pub fn new(
-        spi: hal::spi::Spi<hal::stm32::SPI5, hal::spi::Enabled, u16>,
-        stream: hal::dma::dma::Stream5<hal::stm32::DMA1>,
-        trigger_channel: sampling_timer::tim2::Channel4,
-    ) -> Self {
-        // Generate DMA events when an output compare of the timer hitting zero (timer roll over)
-        // occurs.
-        trigger_channel.listen_dma();
-        trigger_channel.to_output_compare(0);
-
-        // The trigger stream constantly writes to the TX FIFO to generate DAC updates.
-        let trigger_config = DmaConfig::default()
-            .memory_increment(true)
-            .peripheral_increment(false)
-            .circular_buffer(true);
-
-        // Listen for any SPI errors, as this may indicate that we are not generating updates on the
-        // DAC.
-        let mut spi = spi.disable();
-        spi.listen(hal::spi::Event::Error);
-
-        // Allow the SPI FIFOs to operate using only DMA data channels.
-        spi.enable_dma_tx();
-
-        // Enable SPI and start it in infinite transaction mode.
-        spi.inner().cr1.modify(|_, w| w.spe().set_bit());
-        spi.inner().cr1.modify(|_, w| w.cstart().started());
-
-        // Construct the stream to write from memory to the peripheral.
-        let transfer: Transfer<_, _, MemoryToPeripheral, _> = Transfer::init(
-            stream,
-            SPI5::new(trigger_channel, spi),
-            // Note(unsafe): This buffer is only used once and provided to the transfer.
-            unsafe { &mut DAC1_BUF0 },
-            None,
-            trigger_config,
-        );
-
-        Self {
-            // Note(unsafe): This buffer is only used once and provided for the next DMA transfer.
-            next_buffer: unsafe { Some(&mut DAC1_BUF1) },
-            transfer,
-            first_transfer: true,
-        }
-    }
-
-    /// Mutably borrow the next output buffer to populate it with DAC codes.
-    pub fn prepare_buffer(&mut self) -> &mut [u16; SAMPLE_BUFFER_SIZE] {
-        self.next_buffer.as_mut().unwrap()
-    }
-
-    /// Enqueue the next buffer for transmission to the DAC.
-    ///
-    /// # Args
-    /// * `data` - The next data to write to the DAC.
-    pub fn commit_buffer(&mut self) {
-        let next_buffer = self.next_buffer.take().unwrap();
-
-        // If the last transfer was not complete, we didn't write all our previous DAC codes.
-        // Wait for all the DAC codes to get written as well.
-        if self.first_transfer {
-            self.first_transfer = false
-        } else {
-            // Note: If a device hangs up, check that this conditional is passing correctly, as
-            // there is no time-out checks here in the interest of execution speed.
-            while self.transfer.get_transfer_complete_flag() == false {}
+        impl $spi {
+            pub fn new(
+                _channel: sampling_timer::tim2::$trigger_channel,
+                spi: hal::spi::Spi<hal::stm32::$spi, hal::spi::Disabled, u16>,
+            ) -> Self {
+                Self { _channel, spi }
+            }
         }
 
-        // Start the next transfer.
-        self.transfer.clear_interrupts();
-        let (prev_buffer, _) =
-            self.transfer.next_transfer(next_buffer).unwrap();
+        // Note(unsafe): This is safe because the DMA request line is logically owned by this module.
+        // Additionally, the SPI is owned by this structure and is known to be configured for u16 word
+        // sizes.
+        unsafe impl TargetAddress<MemoryToPeripheral> for $spi {
+            /// SPI is configured to operate using 16-bit transfer words.
+            type MemSize = u16;
 
-        self.next_buffer.replace(prev_buffer);
-    }
+            /// SPI DMA requests are generated whenever TIM2 CH3 comparison occurs.
+            const REQUEST_LINE: Option<u8> = Some(DMAReq::$dma_req as u8);
+
+            /// Whenever the DMA request occurs, it should write into SPI's TX FIFO.
+            fn address(&self) -> u32 {
+                &self.spi.inner().txdr as *const _ as u32
+            }
+        }
+
+        /// Represents data associated with DAC0.
+        pub struct $name {
+            next_buffer: Option<&'static mut [u16; SAMPLE_BUFFER_SIZE]>,
+            // Note: SPI TX functionality may not be used from this structure to ensure safety with DMA.
+            transfer: Transfer<
+                hal::dma::dma::$data_stream<hal::stm32::DMA1>,
+                $spi,
+                MemoryToPeripheral,
+                &'static mut [u16; SAMPLE_BUFFER_SIZE],
+            >,
+            first_transfer: bool,
+        }
+
+        impl $name {
+            /// Construct the DAC output channel.
+            ///
+            /// # Args
+            /// * `spi` - The SPI interface used to communicate with the ADC.
+            /// * `stream` - The DMA stream used to write DAC codes over SPI.
+            /// * `trigger_channel` - The sampling timer output compare channel for update triggers.
+            pub fn new(
+                spi: hal::spi::Spi<hal::stm32::$spi, hal::spi::Enabled, u16>,
+                stream: hal::dma::dma::$data_stream<hal::stm32::DMA1>,
+                trigger_channel: sampling_timer::tim2::$trigger_channel,
+            ) -> Self {
+                // Generate DMA events when an output compare of the timer hitting zero (timer roll over)
+                // occurs.
+                trigger_channel.listen_dma();
+                trigger_channel.to_output_compare(0);
+
+                // The stream constantly writes to the TX FIFO to write new update codes.
+                let trigger_config = DmaConfig::default()
+                    .memory_increment(true)
+                    .peripheral_increment(false);
+
+                // Listen for any potential SPI error signals, which may indicate that we are not generating
+                // update codes.
+                let mut spi = spi.disable();
+                spi.listen(hal::spi::Event::Error);
+
+                // Allow the SPI FIFOs to operate using only DMA data channels.
+                spi.enable_dma_tx();
+
+                // Enable SPI and start it in infinite transaction mode.
+                spi.inner().cr1.modify(|_, w| w.spe().set_bit());
+                spi.inner().cr1.modify(|_, w| w.cstart().started());
+
+                // Construct the trigger stream to write from memory to the peripheral.
+                let transfer: Transfer<_, _, MemoryToPeripheral, _> =
+                    Transfer::init(
+                        stream,
+                        $spi::new(trigger_channel, spi),
+                        // Note(unsafe): This buffer is only used once and provided for the DMA transfer.
+                        unsafe { &mut DAC_BUF[$index][0] },
+                        None,
+                        trigger_config,
+                    );
+
+                Self {
+                    transfer,
+                    // Note(unsafe): This buffer is only used once and provided for the next DMA transfer.
+                    next_buffer: unsafe { Some(&mut DAC_BUF[$index][1]) },
+                    first_transfer: true,
+                }
+            }
+
+            /// Mutably borrow the next output buffer to populate it with DAC codes.
+            pub fn prepare_buffer(&mut self) -> &mut [u16; SAMPLE_BUFFER_SIZE] {
+                self.next_buffer.as_mut().unwrap()
+            }
+
+            /// Enqueue the next buffer for transmission to the DAC.
+            ///
+            /// # Args
+            /// * `data` - The next data to write to the DAC.
+            pub fn commit_buffer(&mut self) {
+                let next_buffer = self.next_buffer.take().unwrap();
+
+                // If the last transfer was not complete, we didn't write all our previous DAC codes.
+                // Wait for all the DAC codes to get written as well.
+                if self.first_transfer {
+                    self.first_transfer = false
+                } else {
+                    // Note: If a device hangs up, check that this conditional is passing correctly, as
+                    // there is no time-out checks here in the interest of execution speed.
+                    while self.transfer.get_transfer_complete_flag() == false {}
+                }
+
+                // Start the next transfer.
+                self.transfer.clear_interrupts();
+                let (prev_buffer, _) =
+                    self.transfer.next_transfer(next_buffer).unwrap();
+
+                self.next_buffer.replace(prev_buffer);
+            }
+        }
+    };
 }
+
+dac_output!(Dac0Output, 0, Stream4, SPI4, Channel3, TIM2_CH3);
+dac_output!(Dac1Output, 1, Stream5, SPI5, Channel4, TIM2_CH4);

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,8 +185,7 @@ macro_rules! route_request {
 #[rtic::app(device = stm32h7xx_hal::stm32, peripherals = true, monotonic = rtic::cyccnt::CYCCNT)]
 const APP: () = {
     struct Resources {
-        afe0: AFE0,
-        afe1: AFE1,
+        afes: (AFE0, AFE1),
 
         adcs: (Adc0Input, Adc1Input),
         dacs: (Dac0Output, Dac1Output),
@@ -729,8 +728,7 @@ const APP: () = {
         sampling_timer.start();
 
         init::LateResources {
-            afe0: afe0,
-            afe1: afe1,
+            afes: (afe0, afe1),
 
             adcs,
             dacs,
@@ -768,7 +766,7 @@ const APP: () = {
         c.resources.dacs.1.commit_buffer();
     }
 
-    #[idle(resources=[net_interface, pounder, mac_addr, eth_mac, iir_state, iir_ch, afe0, afe1])]
+    #[idle(resources=[net_interface, pounder, mac_addr, eth_mac, iir_state, iir_ch, afes])]
     fn idle(mut c: idle::Context) -> ! {
         let mut socket_set_entries: [_; 8] = Default::default();
         let mut sockets =
@@ -828,8 +826,8 @@ const APP: () = {
 
                                     Ok::<server::Status, ()>(state)
                                 }),
-                                "stabilizer/afe0/gain": (|| c.resources.afe0.get_gain()),
-                                "stabilizer/afe1/gain": (|| c.resources.afe1.get_gain()),
+                                "stabilizer/afe0/gain": (|| c.resources.afes.0.get_gain()),
+                                "stabilizer/afe1/gain": (|| c.resources.afes.1.get_gain()),
                                 "pounder/in0": (|| {
                                     match c.resources.pounder {
                                         Some(pounder) =>
@@ -924,10 +922,10 @@ const APP: () = {
                                     }
                                 }),
                                 "stabilizer/afe0/gain": afe::Gain, (|gain| {
-                                    Ok::<(), ()>(c.resources.afe0.set_gain(gain))
+                                    Ok::<(), ()>(c.resources.afes.0.set_gain(gain))
                                 }),
                                 "stabilizer/afe1/gain": afe::Gain, (|gain| {
-                                    Ok::<(), ()>(c.resources.afe1.set_gain(gain))
+                                    Ok::<(), ()>(c.resources.afes.1.set_gain(gain))
                                 })
                             ]
                         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -763,9 +763,6 @@ const APP: () = {
                 dac_samples[channel][sample] = y as i16 as u16 ^ 0x8000;
             }
         }
-        let [adc0, adc1] = adc_samples;
-        c.resources.adcs.0.release_buffer(adc0);
-        c.resources.adcs.0.release_buffer(adc1);
         let [dac0, dac1] = dac_samples;
         c.resources.dacs.0.release_buffer(dac0);
         c.resources.dacs.1.release_buffer(dac1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ mod pounder;
 mod sampling_timer;
 mod server;
 
-use adc::{Adc0Input, Adc1Input, AdcInputs};
+use adc::{Adc0Input, Adc1Input};
 use dac::{Dac0Output, Dac1Output, DacOutputs};
 use dsp::iir;
 
@@ -188,7 +188,7 @@ const APP: () = {
         afe0: AFE0,
         afe1: AFE1,
 
-        adcs: AdcInputs,
+        adcs: (Adc0Input, Adc1Input),
         dacs: DacOutputs,
 
         eeprom_i2c: hal::i2c::I2c<hal::stm32::I2C2>,
@@ -356,7 +356,7 @@ const APP: () = {
                 )
             };
 
-            AdcInputs::new(adc0, adc1)
+            (adc0, adc1)
         };
 
         let dacs = {
@@ -746,8 +746,8 @@ const APP: () = {
 
     #[task(binds=DMA1_STR3, resources=[adcs, dacs, iir_state, iir_ch], priority=2)]
     fn adc_update(c: adc_update::Context) {
-        let (adc0_samples, adc1_samples) =
-            c.resources.adcs.transfer_complete_handler();
+        let adc0_samples = c.resources.adcs.0.transfer_complete_handler();
+        let adc1_samples = c.resources.adcs.1.transfer_complete_handler();
 
         let (dac0, dac1) = c.resources.dacs.prepare_data();
 


### PR DESCRIPTION
I wanted to try macros.
This moves the ADC and DAC DMA setup into macros reducing code footprint. Hopefully no functional changes there.
I didn't test this on hardware and I may have missed differences between `Adc0`/`Adc1` and `Dac0`/`Dac1`.

It removes the `AdcInputs` and `DacOutputs` structs and replaces them with tuples as they were just fan-outs/fan-ins.
It also does some minor tweaks in the `process()` ISR towards higher flexibility enforces some data patterns to help the compiler.

Differences missing:
* [x] `.transfer_complete_interrupt(true)` for `Adc1` only: needed
* [x] `.circular_buffer(true);` for `Dac1` only: close #183 