### PR TITLE
Removing invalid GDB command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+openocd.gdb

--- a/openocd.gdb
+++ b/openocd.gdb
@@ -14,9 +14,6 @@ break DefaultHandler
 break HardFault
 break rust_begin_unwind
 
-source ../../PyCortexMDebug/cmdebug/svd_gdb.py
-svd_load ~/Downloads/STM32H743x.svd
-
 load
 # tbreak cortex_m_rt::reset_handler
 monitor reset halt


### PR DESCRIPTION
This PR fixes #244 by updating the GDB file and adding it to gitignore so changes to it aren't tracked automatically by git (note: users can still make changes and commit them by `--force`ing the addition).