### PR TITLE
Adding support for cargo-embed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 openocd.gdb
+Embed.toml

--- a/Embed.toml
+++ b/Embed.toml
@@ -1,0 +1,3 @@
+[default.general]
+chip = "STM32H743ZITx"
+connect_under_reset = true

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ See https://github.com/sinara-hw/Stabilizer
 * `cargo build --release`
 * Do not try the debug (default) mode. It is guaranteed to panic.
 
+### Using Cargo-embed
+
+* Install `cargo-embed`: `cargo install cargo-embed`
+* Program the device: `cargo embed --bin dual-iir --release`
+
 ### Using GDB/OpenOCD
 
 * Get a recent openocd, a JTAG adapter ("st-link" or some clone) and


### PR DESCRIPTION
This PR adds support for flashing using cargo-embed to simplify the flashing process. This removes the need for `openocd` and external tooling when flashing a complete binary. 