### PR TITLE
bump HAL and smoltcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,6 +966,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "smoltcp"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab527c390c7e107f687bd92a886a083fde61b8cdc700b37f3d7e4346ffd8fae1"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "managed",
+]
+
+[[package]]
 name = "stabilizer"
 version = "0.4.1"
 dependencies = [
@@ -987,7 +998,7 @@ dependencies = [
  "paste",
  "serde",
  "serde-json-core",
- "smoltcp",
+ "smoltcp 0.7.0",
  "stm32h7xx-hal",
 ]
 
@@ -1022,7 +1033,7 @@ dependencies = [
  "embedded-hal",
  "nb 1.0.0",
  "paste",
- "smoltcp",
+ "smoltcp 0.6.0",
  "stm32h7",
  "void",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,7 +1023,7 @@ dependencies = [
 [[package]]
 name = "stm32h7xx-hal"
 version = "0.8.0"
-source = "git+https://github.com/stm32-rs/stm32h7xx-hal?branch=dma#3da22d4935c8f6e412b99e6662ec11da5265fb88"
+source = "git+https://github.com/stm32-rs/stm32h7xx-hal?branch=dma#2b8a04caac566a8560f400ddd6503508f78bea77"
 dependencies = [
  "bare-metal 1.0.0",
  "cast",
@@ -1033,7 +1033,7 @@ dependencies = [
  "embedded-hal",
  "nb 1.0.0",
  "paste",
- "smoltcp 0.6.0",
+ "smoltcp 0.7.0",
  "stm32h7",
  "void",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,17 +956,6 @@ dependencies = [
 
 [[package]]
 name = "smoltcp"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe46639fd2ec79eadf8fe719f237a7a0bd4dac5d957f1ca5bbdbc1c3c39e53a"
-dependencies = [
- "bitflags",
- "byteorder",
- "managed",
-]
-
-[[package]]
-name = "smoltcp"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab527c390c7e107f687bd92a886a083fde61b8cdc700b37f3d7e4346ffd8fae1"
@@ -998,7 +987,7 @@ dependencies = [
  "paste",
  "serde",
  "serde-json-core",
- "smoltcp 0.7.0",
+ "smoltcp",
  "stm32h7xx-hal",
 ]
 
@@ -1033,7 +1022,7 @@ dependencies = [
  "embedded-hal",
  "nb 1.0.0",
  "paste",
- "smoltcp 0.7.0",
+ "smoltcp",
  "stm32h7",
  "void",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ ad9959 = { path = "ad9959" }
 git = "https://github.com/mrd0ll4r/mcp23017.git"
 
 [dependencies.smoltcp]
-version = "0.6"
+version = "0.7"
 features = ["ethernet", "proto-ipv4", "socket-tcp", "proto-ipv6"]
 default-features = false
 

--- a/src/hardware/adc.rs
+++ b/src/hardware/adc.rs
@@ -180,18 +180,21 @@ macro_rules! adc_input {
                     hal::spi::Spi<hal::stm32::$spi, hal::spi::Disabled, u16>,
                     PeripheralToMemory,
                     &'static mut [u16; SAMPLE_BUFFER_SIZE],
+                    hal::dma::DBTransfer,
                 >,
                 trigger_transfer: Transfer<
                     hal::dma::dma::$trigger_stream<hal::stm32::DMA1>,
                     [< $spi CR >],
                     MemoryToPeripheral,
                     &'static mut [u32; 1],
+                    hal::dma::DBTransfer,
                 >,
                 clear_transfer: Transfer<
                     hal::dma::dma::$clear_stream<hal::stm32::DMA1>,
                     [< $spi IFCR >],
                     MemoryToPeripheral,
                     &'static mut [u32; 1],
+                    hal::dma::DBTransfer,
                 >,
             }
 
@@ -239,6 +242,7 @@ macro_rules! adc_input {
                         _,
                         MemoryToPeripheral,
                         _,
+                        _,
                     > = Transfer::init(
                         clear_stream,
                         [< $spi IFCR >]::new(clear_channel),
@@ -276,6 +280,7 @@ macro_rules! adc_input {
                         _,
                         MemoryToPeripheral,
                         _,
+                        _,
                     > = Transfer::init(
                         trigger_stream,
                         [< $spi CR >]::new(trigger_channel),
@@ -306,7 +311,7 @@ macro_rules! adc_input {
 
                     // The data transfer is always a transfer of data from the peripheral to a RAM
                     // buffer.
-                    let data_transfer: Transfer<_, _, PeripheralToMemory, _> =
+                    let data_transfer: Transfer<_, _, PeripheralToMemory, _, _> =
                         Transfer::init(
                             data_stream,
                             spi,

--- a/src/hardware/dac.rs
+++ b/src/hardware/dac.rs
@@ -122,6 +122,7 @@ macro_rules! dac_output {
                 $spi,
                 MemoryToPeripheral,
                 &'static mut [u16; SAMPLE_BUFFER_SIZE],
+                hal::dma::DBTransfer,
             >,
         }
 
@@ -164,7 +165,7 @@ macro_rules! dac_output {
                 }
 
                 // Construct the trigger stream to write from memory to the peripheral.
-                let transfer: Transfer<_, _, MemoryToPeripheral, _> =
+                let transfer: Transfer<_, _, MemoryToPeripheral, _, _> =
                     Transfer::init(
                         stream,
                         $spi::new(trigger_channel, spi),

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -38,8 +38,6 @@ pub type AFE1 = afe::ProgrammableGainAmplifier<
 // Type alias for the ethernet interface on Stabilizer.
 pub type Ethernet = smoltcp::iface::EthernetInterface<
     'static,
-    'static,
-    'static,
     hal::ethernet::EthernetDMA<'static>,
 >;
 

--- a/src/hardware/pounder/timestamp.rs
+++ b/src/hardware/pounder/timestamp.rs
@@ -43,6 +43,7 @@ pub struct Timestamper {
         timers::tim8::Channel1InputCapture,
         PeripheralToMemory,
         &'static mut [u16; SAMPLE_BUFFER_SIZE],
+        hal::dma::DBTransfer,
     >,
 }
 
@@ -89,7 +90,7 @@ impl Timestamper {
         input_capture.listen_dma();
 
         // The data transfer is always a transfer of data from the peripheral to a RAM buffer.
-        let data_transfer: Transfer<_, _, PeripheralToMemory, _> =
+        let data_transfer: Transfer<_, _, PeripheralToMemory, _, _> =
             Transfer::init(
                 stream,
                 input_capture,


### PR DESCRIPTION
This bumps the HAL (still dma branch) and smoltcp (to 0.7).
Removes a few lifetime parameters due to the smoltcp changes. Adds type parameters to `dma::Transfer`.

* [x] Test on hardware