### PR TITLE
Updating input capture for timers

### DIFF
--- a/src/bin/lockin-external.rs
+++ b/src/bin/lockin-external.rs
@@ -71,6 +71,9 @@ const APP: () = {
         // Start sampling ADCs.
         stabilizer.adc_dac_timer.start();
 
+        // Enable the timestamper.
+        stabilizer.timestamper.start();
+
         init::LateResources {
             afes: stabilizer.afes,
             adcs: stabilizer.adcs,

--- a/src/hardware/digital_input_stamper.rs
+++ b/src/hardware/digital_input_stamper.rs
@@ -45,7 +45,7 @@ impl InputStamper {
         // Utilize the TIM5 CH4 as an input capture channel - use TI4 (the DI0 input trigger) as the
         // capture source.
         let input_capture =
-            timer_channel.into_input_capture(timers::CaptureTrigger::Input24);
+            timer_channel.into_input_capture(timers::tim5::CaptureSource4::TI4);
 
         Self {
             capture_channel: input_capture,

--- a/src/hardware/pounder/timestamp.rs
+++ b/src/hardware/pounder/timestamp.rs
@@ -85,7 +85,7 @@ impl Timestamper {
 
         // The capture channel should capture whenever the trigger input occurs.
         let input_capture = capture_channel
-            .into_input_capture(timers::CaptureTrigger::TriggerInput);
+            .into_input_capture(timers::tim8::CaptureSource1::TRC);
         input_capture.listen_dma();
 
         // The data transfer is always a transfer of data from the peripheral to a RAM buffer.

--- a/src/hardware/timers.rs
+++ b/src/hardware/timers.rs
@@ -235,8 +235,6 @@ macro_rules! timer_channels {
             pub struct [< Channel $index InputCapture>] {}
 
             impl [< Channel $index >] {
-
-
                 /// Construct a new timer channel.
                 ///
                 /// Note(unsafe): This function must only be called once. Once constructed, the
@@ -276,7 +274,6 @@ macro_rules! timer_channels {
                     let regs = unsafe { &*<$TY>::ptr() };
 
                     regs.[< $ccmrx _input >]().modify(|_, w| w.[< cc $index s>]().variant(input));
-
 
                     [< Channel $index InputCapture >] {}
                 }

--- a/src/hardware/timers.rs
+++ b/src/hardware/timers.rs
@@ -1,13 +1,14 @@
 ///! The sampling timer is used for managing ADC sampling and external reference timestamping.
 use super::hal;
 
-/// The source of an input capture trigger.
-#[allow(dead_code)]
-pub enum CaptureTrigger {
-    Input13 = 0b01,
-    Input24 = 0b10,
-    TriggerInput = 0b11,
-}
+use hal::stm32::{
+    // TIM1 and TIM8 have identical registers.
+    tim1 as __tim8,
+    tim2 as __tim2,
+    // TIM2 and TIM5 have identical registers.
+    tim2 as __tim5,
+    tim3 as __tim3,
+};
 
 /// The event that should generate an external trigger from the peripheral.
 #[allow(dead_code)]
@@ -225,6 +226,8 @@ macro_rules! timer_channels {
 
     ($index:expr, $TY:ty, $ccmrx:expr, $size:ty) => {
         paste::paste! {
+            pub use super::[< __ $TY:lower >]::[< $ccmrx _input >]::[< CC $index S_A>] as [< CaptureSource $index >];
+
             /// A capture/compare channel of the timer.
             pub struct [< Channel $index >] {}
 
@@ -232,6 +235,8 @@ macro_rules! timer_channels {
             pub struct [< Channel $index InputCapture>] {}
 
             impl [< Channel $index >] {
+
+
                 /// Construct a new timer channel.
                 ///
                 /// Note(unsafe): This function must only be called once. Once constructed, the
@@ -267,12 +272,11 @@ macro_rules! timer_channels {
                 /// # Args
                 /// * `input` - The input source for the input capture event.
                 #[allow(dead_code)]
-                pub fn into_input_capture(self, input: super::CaptureTrigger) -> [< Channel $index InputCapture >]{
+                pub fn into_input_capture(self, input: [< CaptureSource $index >]) -> [< Channel $index InputCapture >]{
                     let regs = unsafe { &*<$TY>::ptr() };
 
-                    // Note(unsafe): The bit configuration is guaranteed to be valid by the
-                    // CaptureTrigger enum definition.
-                    regs.[< $ccmrx _input >]().modify(|_, w| unsafe { w.[< cc $index s>]().bits(input as u8) });
+                    regs.[< $ccmrx _input >]().modify(|_, w| w.[< cc $index s>]().variant(input));
+
 
                     [< Channel $index InputCapture >] {}
                 }
@@ -316,6 +320,9 @@ macro_rules! timer_channels {
                 /// Enable the input capture to begin capturing timer values.
                 #[allow(dead_code)]
                 pub fn enable(&mut self) {
+                    // Read the latest input capture to clear any pending data in the register.
+                    let _ = self.latest_capture();
+
                     // Note(unsafe): This channel owns all access to the specific timer channel.
                     // Only atomic operations on completed on the timer registers.
                     let regs = unsafe { &*<$TY>::ptr() };


### PR DESCRIPTION
This PR fixes the register configuration for input capture configurations and updates the lockin-external application to enable the timestamp capture mechanism.

**Testing**

Debug code was inserted into the DSP routine such that a log was generated after each 1000 samples. A 1KHz signal was plugged in to the DI0 input and it was verified that after approximately 1 second, a break-point tripped at the 1000 sample log message.

A capture of DAC0/DAC1 with DI0 and ADC0 driven with a 1KHz signal is shown below:
![DS4_QuickPrint7](https://user-images.githubusercontent.com/8771450/106748751-f11d8980-6625-11eb-9941-3acc0784f697.png)
