### PR TITLE
Adding support for input capture prefilter configuration

### DIFF
--- a/src/hardware/digital_input_stamper.rs
+++ b/src/hardware/digital_input_stamper.rs
@@ -44,12 +44,12 @@ impl InputStamper {
     ) -> Self {
         // Utilize the TIM5 CH4 as an input capture channel - use TI4 (the DI0 input trigger) as the
         // capture source.
-        let input_capture =
+        let mut input_capture =
             timer_channel.into_input_capture(timers::tim5::CaptureSource4::TI4);
 
-        // FIXME: hack in de-glitching filter
-        let regs = unsafe { &*hal::stm32::TIM5::ptr() };
-        regs.ccmr2_input().modify(|_, w| w.ic4f().bits(0b0011));
+        // Do not prescale the input capture signal - require 8 consecutive samples to record an
+        // incoming event - this prevents spurious glitches from triggering captures.
+        input_capture.configure_filter(timers::InputFilter::Div1N8);
 
         Self {
             capture_channel: input_capture,

--- a/src/hardware/timers.rs
+++ b/src/hardware/timers.rs
@@ -348,6 +348,8 @@ macro_rules! timer_channels {
                 /// * `filter` - The desired input filter stage configuration. Defaults to disabled.
                 #[allow(dead_code)]
                 pub fn configure_filter(&mut self, filter: super::InputFilter) {
+                    // Note(unsafe): This channel owns all access to the specific timer channel.
+                    // Only atomic operations on completed on the timer registers.
                     let regs = unsafe { &*<$TY>::ptr() };
                     regs.[< $ccmrx _input >]().modify(|_, w| w.[< ic $index f >]().bits(filter as u8));
                 }

--- a/src/hardware/timers.rs
+++ b/src/hardware/timers.rs
@@ -48,6 +48,13 @@ pub enum SlaveMode {
     Trigger = 0b0110,
 }
 
+/// Optional input capture preconditioning filter configurations.
+#[allow(dead_code)]
+pub enum InputFilter {
+    Div1N1 = 0b0000,
+    Div1N8 = 0b0011,
+}
+
 macro_rules! timer_channels {
     ($name:ident, $TY:ident, $size:ty) => {
         paste::paste! {
@@ -333,6 +340,16 @@ macro_rules! timer_channels {
                     // Only atomic operations on completed on the timer registers.
                     let regs = unsafe { &*<$TY>::ptr() };
                     regs.sr.read().[< cc $index of >]().bit_is_set()
+                }
+
+                /// Configure the input capture input pre-filter.
+                ///
+                /// # Args
+                /// * `filter` - The desired input filter stage configuration. Defaults to disabled.
+                #[allow(dead_code)]
+                pub fn configure_filter(&mut self, filter: super::InputFilter) {
+                    let regs = unsafe { &*<$TY>::ptr() };
+                    regs.[< $ccmrx _input >]().modify(|_, w| w.[< ic $index f >]().bits(filter as u8));
                 }
             }
 


### PR DESCRIPTION
This adds support for configuring the input capture prefilter for an input capture channel.

I looked through timers TIM1-TIM5, and TIM8, and all of them have the same filter configurations from what I can tell. There's no unique enums for the prefilter configuration unfortunately.

TODO:
- [ ] Test on hardware for proper configuration