### PR TITLE
Updating minconf + minimq dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "minimq"
 version = "0.2.0"
-source = "git+https://github.com/quartiq/minimq.git?branch=feature/optional-client-id#6777c669604fd1c8043742314159e9090ed4f115"
+source = "git+https://github.com/quartiq/minimq.git?branch=master#a89a6f11d0d1f63114fb15f676022eb4fe904f56"
 dependencies = [
  "bit_field",
  "embedded-nal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,7 @@ dependencies = [
 [[package]]
 name = "derive_miniconf"
 version = "0.1.0"
+source = "git+https://github.com/quartiq/miniconf.git?branch=rs/crate-scope-derive#dbd3dfb0ea79b7227c9f217849817601adfa4421"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -401,6 +402,7 @@ dependencies = [
 [[package]]
 name = "miniconf"
 version = "0.1.0"
+source = "git+https://github.com/quartiq/miniconf.git?branch=rs/crate-scope-derive#dbd3dfb0ea79b7227c9f217849817601adfa4421"
 dependencies = [
  "derive_miniconf",
  "heapless",
@@ -412,8 +414,7 @@ dependencies = [
 [[package]]
 name = "minimq"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5e626690b6f62e15710cf9815e5ca25ee54084899298c100a14b2504c80a46"
+source = "git+https://github.com/quartiq/minimq.git?branch=feature/optional-client-id#18c277088d427a54b8fdb49f2755ffda2479bf3f"
 dependencies = [
  "bit_field",
  "embedded-nal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,9 +199,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_stringset"
+name = "derive_miniconf"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/miniconf.git?branch=develop#97ace3d8268075235cb67a2a8740d200bea1fe30"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -402,9 +401,8 @@ dependencies = [
 [[package]]
 name = "miniconf"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/miniconf.git?branch=develop#97ace3d8268075235cb67a2a8740d200bea1fe30"
 dependencies = [
- "derive_stringset",
+ "derive_miniconf",
  "heapless",
  "minimq",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 [[package]]
 name = "derive_miniconf"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/miniconf.git?branch=rs/crate-scope-derive#dbd3dfb0ea79b7227c9f217849817601adfa4421"
+source = "git+https://github.com/quartiq/miniconf.git?branch=develop#394d0634a9622e43a55850afc34eb4695ecababa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "miniconf"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/miniconf.git?branch=rs/crate-scope-derive#dbd3dfb0ea79b7227c9f217849817601adfa4421"
+source = "git+https://github.com/quartiq/miniconf.git?branch=develop#394d0634a9622e43a55850afc34eb4695ecababa"
 dependencies = [
  "derive_miniconf",
  "heapless",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "minimq"
 version = "0.2.0"
-source = "git+https://github.com/quartiq/minimq.git?branch=feature/optional-client-id#18c277088d427a54b8fdb49f2755ffda2479bf3f"
+source = "git+https://github.com/quartiq/minimq.git?branch=feature/optional-client-id#6777c669604fd1c8043742314159e9090ed4f115"
 dependencies = [
  "bit_field",
  "embedded-nal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ branch = "develop"
 
 [patch.crates-io.minimq]
 git = "https://github.com/quartiq/minimq.git"
-branch = "feature/optional-client-id"
+branch = "master"
 
 [patch.crates-io.serde-json-core]
 git = "https://github.com/rust-embedded-community/serde-json-core.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,7 @@ miniconf = "0.1"
 generic-array = "0.14"
 
 [patch.crates-io.miniconf]
-git = "https://github.com/quartiq/miniconf.git"
-branch = "develop"
+path = "../miniconf/"
 
 [patch.crates-io.serde-json-core]
 git = "https://github.com/rust-embedded-community/serde-json-core.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ generic-array = "0.14"
 
 [patch.crates-io.miniconf]
 git = "https://github.com/quartiq/miniconf.git"
-branch = "rs/crate-scope-derive"
+branch = "develop"
 
 [patch.crates-io.minimq]
 git = "https://github.com/quartiq/minimq.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,12 @@ miniconf = "0.1"
 generic-array = "0.14"
 
 [patch.crates-io.miniconf]
-path = "../miniconf/"
+git = "https://github.com/quartiq/miniconf.git"
+branch = "rs/crate-scope-derive"
+
+[patch.crates-io.minimq]
+git = "https://github.com/quartiq/minimq.git"
+branch = "feature/optional-client-id"
 
 [patch.crates-io.serde-json-core]
 git = "https://github.com/rust-embedded-community/serde-json-core.git"

--- a/dsp/src/iir.rs
+++ b/dsp/src/iir.rs
@@ -1,4 +1,4 @@
-use miniconf::StringSet;
+use miniconf::MiniconfAtomic;
 use serde::Deserialize;
 
 use super::{abs, copysign, macc, max, min};
@@ -39,7 +39,7 @@ pub type Vec5 = [f32; 5];
 ///   Therefore it can trivially implement bump-less transfer.
 /// * Cascading multiple IIR filters allows stable and robust
 ///   implementation of transfer functions beyond bequadratic terms.
-#[derive(Copy, Clone, Debug, Default, Deserialize, StringSet)]
+#[derive(Copy, Clone, Debug, Default, Deserialize, MiniconfAtomic)]
 pub struct IIR {
     pub ba: Vec5,
     pub y_offset: f32,

--- a/dsp/src/iir_int.rs
+++ b/dsp/src/iir_int.rs
@@ -1,6 +1,6 @@
 use super::tools::macc_i32;
 use core::f64::consts::PI;
-use miniconf::StringSet;
+use miniconf::MiniconfAtomic;
 use serde::Deserialize;
 
 /// Generic vector for integer IIR filter.
@@ -46,7 +46,7 @@ impl Coeff for Vec5 {
 /// See `dsp::iir::IIR` for general implementation details.
 /// Offset and limiting disabled to suit lowpass applications.
 /// Coefficient scaling fixed and optimized.
-#[derive(Copy, Clone, Default, Debug, StringSet, Deserialize)]
+#[derive(Copy, Clone, Default, Debug, MiniconfAtomic, Deserialize)]
 pub struct IIR {
     pub ba: Vec5,
     // pub y_offset: i32,

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -63,7 +63,7 @@ const APP: () = {
         let mqtt_interface = {
             let mqtt_client = {
                 let broker = IpAddr::V4(Ipv4Addr::new(10, 34, 16, 1));
-                minimq::MqttClient::new(broker, None, stabilizer.net.stack)
+                minimq::MqttClient::new(broker, "", stabilizer.net.stack)
                     .unwrap()
             };
 

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -63,12 +63,8 @@ const APP: () = {
         let mqtt_interface = {
             let mqtt_client = {
                 let broker = IpAddr::V4(Ipv4Addr::new(10, 34, 16, 1));
-                minimq::MqttClient::new(
-                    broker,
-                    "stabilizer",
-                    stabilizer.net.stack,
-                )
-                .unwrap()
+                minimq::MqttClient::new(broker, None, stabilizer.net.stack)
+                    .unwrap()
             };
 
             MqttInterface::new(mqtt_client, "stabilizer", Settings::default())

--- a/src/hardware/afe.rs
+++ b/src/hardware/afe.rs
@@ -1,11 +1,11 @@
-use miniconf::StringSet;
+use miniconf::Miniconf;
 use serde::{Deserialize, Serialize};
 
 use core::convert::TryFrom;
 use enum_iterator::IntoEnumIterator;
 
 #[derive(
-    Copy, Clone, Debug, Serialize, Deserialize, IntoEnumIterator, StringSet,
+    Copy, Clone, Debug, Serialize, Deserialize, IntoEnumIterator, Miniconf,
 )]
 pub enum Gain {
     G1 = 0b00,

--- a/stabilizer.py
+++ b/stabilizer.py
@@ -108,10 +108,6 @@ async def configure_settings(args):
     response = await interface.command(f'settings/{args.setting}', json.dumps(request))
     logger.info(response)
 
-    if args.commit:
-        response = await interface.command('commit', 'commit')
-        logger.info(response)
-
 
 def main():
     """ Main program entry point. """
@@ -122,8 +118,6 @@ def main():
     parser.add_argument('--broker', default='10.34.16.1', type=str, help='The MQTT broker address')
     parser.add_argument('values', nargs='+', type=str,
                         help='The value of settings. key=value list or a single value is accepted.')
-    parser.add_argument('--commit', action='store_true',
-                        help='Specified true to commit after updating settings.')
     parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose logging')
 
     args = parser.parse_args()


### PR DESCRIPTION
This PR updates stabilizer to use the latest versions of miniconf and minimq. This adds:
* atomic updates of register blocks
* Requirements to configure settings at the terminal (leaf) node
* Support for unspecified, auto-assigned client IDs

This PR fixes #288 by removing the concept of "committing" settings in favor of continuous update.