### PR TITLE
Feature/dhcp support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ dependencies = [
 [[package]]
 name = "minimq"
 version = "0.2.0"
-source = "git+https://github.com/quartiq/minimq.git?branch=feature/init-update#e686ccd89090f32990661fe49416d570e2e80835"
+source = "git+https://github.com/quartiq/minimq.git#933687c2e4bc8a4d972de9a4d1508b0b554a8b38"
 dependencies = [
  "bit_field",
  "embedded-nal",
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "smoltcp-nal"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/smoltcp-nal.git?branch=feature/dhcp-support#5c62caa539d011c45453314c5872e9ca9cd9f780"
+source = "git+https://github.com/quartiq/smoltcp-nal.git?branch=feature/dhcp-support#b3de37939140d04a64c79afddb97b81ff49e1f23"
 dependencies = [
  "embedded-nal",
  "heapless 0.6.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "smoltcp-nal"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/smoltcp-nal.git?branch=feature/dhcp-support#b3de37939140d04a64c79afddb97b81ff49e1f23"
+source = "git+https://github.com/quartiq/smoltcp-nal.git?branch=feature/dhcp-support#79fd03e3d051402c71116839606e5b3294372c98"
 dependencies = [
  "embedded-nal",
  "heapless 0.6.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "smoltcp-nal"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/smoltcp-nal.git?branch=feature/dhcp-support#79fd03e3d051402c71116839606e5b3294372c98"
+source = "git+https://github.com/quartiq/smoltcp-nal.git?branch=main#56519012d7c6a382eaa0d7ecb26f2701771d9ce8"
 dependencies = [
  "embedded-nal",
  "heapless 0.6.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 [[package]]
 name = "derive_miniconf"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/miniconf.git?branch=develop#394d0634a9622e43a55850afc34eb4695ecababa"
+source = "git+https://github.com/quartiq/miniconf.git?branch=develop#314fa5587d1aa28e1ad70106f19e30db646e9f28"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -414,10 +414,10 @@ dependencies = [
 [[package]]
 name = "miniconf"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/miniconf.git?branch=develop#394d0634a9622e43a55850afc34eb4695ecababa"
+source = "git+https://github.com/quartiq/miniconf.git?branch=develop#314fa5587d1aa28e1ad70106f19e30db646e9f28"
 dependencies = [
  "derive_miniconf",
- "heapless 0.5.6",
+ "heapless 0.6.1",
  "minimq",
  "serde",
  "serde-json-core",
@@ -426,13 +426,13 @@ dependencies = [
 [[package]]
 name = "minimq"
 version = "0.2.0"
-source = "git+https://github.com/quartiq/minimq.git?branch=master#a89a6f11d0d1f63114fb15f676022eb4fe904f56"
+source = "git+https://github.com/quartiq/minimq.git?branch=feature/init-update#e686ccd89090f32990661fe49416d570e2e80835"
 dependencies = [
  "bit_field",
  "embedded-nal",
  "enum-iterator",
  "generic-array 0.14.4",
- "heapless 0.5.6",
+ "heapless 0.6.1",
 ]
 
 [[package]]
@@ -714,11 +714,10 @@ dependencies = [
 [[package]]
 name = "smoltcp-nal"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e5aeb4818706fd74c35917692008d29a5314483c8180300a582253718ce57a"
+source = "git+https://github.com/quartiq/smoltcp-nal.git?branch=feature/dhcp-support#5c62caa539d011c45453314c5872e9ca9cd9f780"
 dependencies = [
  "embedded-nal",
- "heapless 0.5.6",
+ "heapless 0.6.1",
  "smoltcp",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,8 +697,7 @@ dependencies = [
 [[package]]
 name = "smoltcp"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab527c390c7e107f687bd92a886a083fde61b8cdc700b37f3d7e4346ffd8fae1"
+source = "git+https://github.com/ryan-summers/smoltcp.git?branch=feature/dhcp-lease-updates#e3954ebb8149341c52a4992e037d4b5109387910"
 dependencies = [
  "bitflags",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ branch = "develop"
 
 [patch.crates-io.minimq]
 git = "https://github.com/quartiq/minimq.git"
-branch = "feature/init-update"
 
 [dependencies.smoltcp-nal]
 git = "https://github.com/quartiq/smoltcp-nal.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ enum-iterator = "0.6.0"
 paste = "1"
 dsp = { path = "dsp" }
 ad9959 = { path = "ad9959" }
-smoltcp-nal = "0.1.0"
 miniconf = "0.1"
 generic-array = "0.14"
 
@@ -54,7 +53,11 @@ branch = "develop"
 
 [patch.crates-io.minimq]
 git = "https://github.com/quartiq/minimq.git"
-branch = "master"
+branch = "feature/init-update"
+
+[dependencies.smoltcp-nal]
+git = "https://github.com/quartiq/smoltcp-nal.git"
+branch = "feature/dhcp-support"
 
 [patch.crates-io.serde-json-core]
 git = "https://github.com/rust-embedded-community/serde-json-core.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ git = "https://github.com/quartiq/minimq.git"
 
 [patch.crates-io.smoltcp-nal]
 git = "https://github.com/quartiq/smoltcp-nal.git"
-branch = "feature/dhcp-support"
+branch = "main"
 
 [patch.crates-io.serde-json-core]
 git = "https://github.com/rust-embedded-community/serde-json-core.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ enum-iterator = "0.6.0"
 paste = "1"
 dsp = { path = "dsp" }
 ad9959 = { path = "ad9959" }
+smoltcp-nal = "0.1."
 miniconf = "0.1"
 generic-array = "0.14"
 
@@ -53,7 +54,7 @@ branch = "develop"
 [patch.crates-io.minimq]
 git = "https://github.com/quartiq/minimq.git"
 
-[dependencies.smoltcp-nal]
+[patch.crates-io.smoltcp-nal]
 git = "https://github.com/quartiq/smoltcp-nal.git"
 branch = "feature/dhcp-support"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ enum-iterator = "0.6.0"
 paste = "1"
 dsp = { path = "dsp" }
 ad9959 = { path = "ad9959" }
-smoltcp-nal = "0.1."
+smoltcp-nal = "0.1.0"
 miniconf = "0.1"
 generic-array = "0.14"
 
@@ -61,6 +61,10 @@ branch = "feature/dhcp-support"
 [patch.crates-io.serde-json-core]
 git = "https://github.com/rust-embedded-community/serde-json-core.git"
 branch = "master"
+
+[patch.crates-io.smoltcp]
+git = "https://github.com/ryan-summers/smoltcp.git"
+branch = "feature/dhcp-lease-updates"
 
 [dependencies.mcp23017]
 git = "https://github.com/mrd0ll4r/mcp23017.git"

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -144,7 +144,13 @@ const APP: () = {
 
         loop {
             let sleep = c.resources.mqtt_interface.lock(|interface| {
-                !interface.network_stack().poll(clock.current_ms())
+                match interface.network_stack().poll(clock.current_ms()) {
+                    Ok(updated) => !updated,
+                    Err(err) => {
+                        log::info!("Network error: {:?}", err);
+                        true
+                    }
+                }
             });
 
             match c

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -148,7 +148,7 @@ const APP: () = {
                     Ok(updated) => !updated,
                     Err(err) => {
                         log::info!("Network error: {:?}", err);
-                        true
+                        false
                     }
                 }
             });

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -147,13 +147,22 @@ const APP: () = {
                 !interface.network_stack().poll(clock.current_ms())
             });
 
-            if c.resources
+            match c
+                .resources
                 .mqtt_interface
-                .lock(|interface| interface.update().unwrap())
+                .lock(|interface| interface.update())
             {
-                c.spawn.settings_update().unwrap()
-            } else if sleep {
-                cortex_m::asm::wfi();
+                Ok(update) => {
+                    if update {
+                        c.spawn.settings_update().unwrap();
+                    } else if sleep {
+                        cortex_m::asm::wfi();
+                    }
+                }
+                Err(miniconf::MqttError::Network(
+                    smoltcp_nal::NetworkError::NoIpAddress,
+                )) => {}
+                Err(error) => log::info!("Unexpected error: {:?}", error),
             }
         }
     }

--- a/src/bin/lockin-external.rs
+++ b/src/bin/lockin-external.rs
@@ -212,7 +212,7 @@ const APP: () = {
                     Ok(updated) => !updated,
                     Err(err) => {
                         log::info!("Network error: {:?}", err);
-                        true
+                        false
                     }
                 }
             });

--- a/src/bin/lockin-external.rs
+++ b/src/bin/lockin-external.rs
@@ -208,7 +208,13 @@ const APP: () = {
 
         loop {
             let sleep = c.resources.mqtt_interface.lock(|interface| {
-                !interface.network_stack().poll(clock.current_ms())
+                match interface.network_stack().poll(clock.current_ms()) {
+                    Ok(updated) => !updated,
+                    Err(err) => {
+                        log::info!("Network error: {:?}", err);
+                        true
+                    }
+                }
             });
 
             if c.resources

--- a/src/hardware/configuration.rs
+++ b/src/hardware/configuration.rs
@@ -19,13 +19,18 @@ use super::{
 
 pub struct NetStorage {
     pub ip_addrs: [smoltcp::wire::IpCidr; 1],
-    pub sockets: [Option<smoltcp::socket::SocketSetItem<'static>>; 1],
+    pub sockets: [Option<smoltcp::socket::SocketSetItem<'static>>; 2],
     pub neighbor_cache:
         [Option<(smoltcp::wire::IpAddress, smoltcp::iface::Neighbor)>; 8],
     pub routes_cache:
         [Option<(smoltcp::wire::IpCidr, smoltcp::iface::Route)>; 8],
     pub tx_storage: [u8; 4096],
     pub rx_storage: [u8; 4096],
+
+    pub dhcp_rx_metadata: [smoltcp::socket::RawPacketMetadata; 1],
+    pub dhcp_tx_metadata: [smoltcp::socket::RawPacketMetadata; 1],
+    pub dhcp_tx_storage: [u8; 600],
+    pub dhcp_rx_storage: [u8; 600],
 }
 
 /// The available networking devices on Stabilizer.
@@ -69,10 +74,15 @@ static mut NET_STORE: NetStorage = NetStorage {
     )],
     neighbor_cache: [None; 8],
     routes_cache: [None; 8],
-    sockets: [None; 1],
+    sockets: [None, None],
 
     tx_storage: [0; 4096],
     rx_storage: [0; 4096],
+
+    dhcp_tx_storage: [0; 600],
+    dhcp_rx_storage: [0; 600],
+    dhcp_rx_metadata: [smoltcp::socket::RawPacketMetadata::EMPTY; 1],
+    dhcp_tx_metadata: [smoltcp::socket::RawPacketMetadata::EMPTY; 1],
 };
 
 /// Configure the stabilizer hardware for operation.
@@ -519,14 +529,17 @@ pub fn setup(
         let store = unsafe { &mut NET_STORE };
 
         store.ip_addrs[0] = smoltcp::wire::IpCidr::new(
-            smoltcp::wire::IpAddress::v4(10, 34, 16, 103),
-            24,
+            smoltcp::wire::IpAddress::Ipv4(
+                smoltcp::wire::Ipv4Address::UNSPECIFIED,
+            ),
+            0,
         );
 
-        let default_v4_gw = smoltcp::wire::Ipv4Address::new(10, 34, 16, 1);
         let mut routes =
             smoltcp::iface::Routes::new(&mut store.routes_cache[..]);
-        routes.add_default_ipv4_route(default_v4_gw).unwrap();
+        routes
+            .add_default_ipv4_route(smoltcp::wire::Ipv4Address::UNSPECIFIED)
+            .unwrap();
 
         let neighbor_cache =
             smoltcp::iface::NeighborCache::new(&mut store.neighbor_cache[..]);
@@ -538,7 +551,7 @@ pub fn setup(
             .routes(routes)
             .finalize();
 
-        let sockets = {
+        let (mut sockets, handles) = {
             // Note(unsafe): Configuration is only called once, so we only access the global
             // storage a single time.
             let socket_storage = unsafe { &mut NET_STORE.sockets[..] };
@@ -562,12 +575,39 @@ pub fn setup(
                 smoltcp::socket::TcpSocket::new(rx_buffer, tx_buffer)
             };
 
-            sockets.add(tcp_socket);
-            sockets
+            let handle = sockets.add(tcp_socket);
+            (sockets, [handle])
+        };
+
+        let dhcp_client = {
+            let rx = unsafe { &mut NET_STORE.dhcp_rx_storage[..] };
+            let tx = unsafe { &mut NET_STORE.dhcp_tx_storage[..] };
+
+            let dhcp_rx_buffer = smoltcp::socket::RawSocketBuffer::new(
+                unsafe { &mut NET_STORE.dhcp_rx_metadata[..] },
+                rx,
+            );
+
+            let dhcp_tx_buffer = smoltcp::socket::RawSocketBuffer::new(
+                unsafe { &mut NET_STORE.dhcp_tx_metadata[..] },
+                tx,
+            );
+
+            smoltcp::dhcp::Dhcpv4Client::new(
+                &mut sockets,
+                dhcp_rx_buffer,
+                dhcp_tx_buffer,
+                smoltcp::time::Instant::from_millis(-1),
+            )
         };
 
         NetworkDevices {
-            stack: smoltcp_nal::NetworkStack::new(interface, sockets),
+            stack: smoltcp_nal::NetworkStack::new(
+                interface,
+                sockets,
+                &handles,
+                Some(dhcp_client),
+            ),
             phy: lan8742a,
         }
     };

--- a/src/hardware/configuration.rs
+++ b/src/hardware/configuration.rs
@@ -597,6 +597,9 @@ pub fn setup(
                 &mut sockets,
                 dhcp_rx_buffer,
                 dhcp_tx_buffer,
+                // Smoltcp indicates that an instant with a negative time is indicative that time is
+                // not yet available. We can't get the current instant yet, so indicate an invalid
+                // time value.
                 smoltcp::time::Instant::from_millis(-1),
             )
         };

--- a/src/hardware/design_parameters.rs
+++ b/src/hardware/design_parameters.rs
@@ -43,7 +43,7 @@ pub const DDS_SYNC_CLK_DIV: u8 = 4;
 // The number of ticks in the ADC sampling timer. The timer runs at 100MHz, so the step size is
 // equal to 10ns per tick.
 // Currently, the sample rate is equal to: Fsample = 100/128 MHz ~ 800 KHz
-pub const ADC_SAMPLE_TICKS_LOG2: u8 = 7;
+pub const ADC_SAMPLE_TICKS_LOG2: u8 = 12;
 pub const ADC_SAMPLE_TICKS: u16 = 1 << ADC_SAMPLE_TICKS_LOG2;
 
 // The desired ADC sample processing buffer size.

--- a/src/hardware/design_parameters.rs
+++ b/src/hardware/design_parameters.rs
@@ -43,7 +43,7 @@ pub const DDS_SYNC_CLK_DIV: u8 = 4;
 // The number of ticks in the ADC sampling timer. The timer runs at 100MHz, so the step size is
 // equal to 10ns per tick.
 // Currently, the sample rate is equal to: Fsample = 100/128 MHz ~ 800 KHz
-pub const ADC_SAMPLE_TICKS_LOG2: u8 = 12;
+pub const ADC_SAMPLE_TICKS_LOG2: u8 = 7;
 pub const ADC_SAMPLE_TICKS: u16 = 1 << ADC_SAMPLE_TICKS_LOG2;
 
 // The desired ADC sample processing buffer size.


### PR DESCRIPTION
Adding DHCP support for stabilizer. Testing was done locally running a DHCP server on a single interface with a single device (stabilizer) connected to a switch.

More robust testing is likely warranted.

TODO:
- [x] Merge https://github.com/quartiq/smoltcp-nal/pull/7