### PR TITLE
Updating smoltcp dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "managed"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75de51135344a4f8ed3cfe2720dc27736f7711989703a0b43aadf3753c55577"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "matrixmultiply"
@@ -697,7 +697,7 @@ dependencies = [
 [[package]]
 name = "smoltcp"
 version = "0.7.0"
-source = "git+https://github.com/ryan-summers/smoltcp.git?branch=feature/dhcp-lease-updates#e3954ebb8149341c52a4992e037d4b5109387910"
+source = "git+https://github.com/smoltcp-rs/smoltcp.git#43567b9743cb9f422de83fad9ff42a6d13f6e5ee"
 dependencies = [
  "bitflags",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,8 @@ git = "https://github.com/rust-embedded-community/serde-json-core.git"
 branch = "master"
 
 [patch.crates-io.smoltcp]
+# We manually patch smoltcp so that we can get access to unreleased updates to the DHCP server. When
+# a new release of smoltcp is made, we can remove this patch.
 git = "https://github.com/smoltcp-rs/smoltcp.git"
 
 [dependencies.mcp23017]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,8 +63,7 @@ git = "https://github.com/rust-embedded-community/serde-json-core.git"
 branch = "master"
 
 [patch.crates-io.smoltcp]
-git = "https://github.com/ryan-summers/smoltcp.git"
-branch = "feature/dhcp-lease-updates"
+git = "https://github.com/smoltcp-rs/smoltcp.git"
 
 [dependencies.mcp23017]
 git = "https://github.com/mrd0ll4r/mcp23017.git"


### PR DESCRIPTION
This PR fixes #316 by updating the smoltcp dependency to point to the mainline smoltcp repository.