### PR TITLE
Fixing ACR write padding

### DIFF
--- a/ad9959/src/lib.rs
+++ b/ad9959/src/lib.rs
@@ -610,10 +610,10 @@ impl ProfileSerializer {
             1 => {
                 // For a pad size of 1, we have to pad with 5 bytes to align things.
                 self.add_write(Register::CSR, &[(self.mode as u8) << 1]);
-                self.add_write(Register::LSRR, &[0, 0, 0]);
+                self.add_write(Register::LSRR, &[0, 0]);
             }
             2 => self.add_write(Register::CSR, &[(self.mode as u8) << 1]),
-            3 => self.add_write(Register::LSRR, &[0, 0, 0]),
+            3 => self.add_write(Register::LSRR, &[0, 0]),
             4 => {}
 
             _ => unreachable!(),

--- a/ad9959/src/lib.rs
+++ b/ad9959/src/lib.rs
@@ -583,7 +583,7 @@ impl ProfileSerializer {
         }
 
         if let Some(acr) = acr {
-            self.add_write(Register::ACR, &acr.to_be_bytes()[1..=4]);
+            self.add_write(Register::ACR, &acr.to_be_bytes()[1..=3]);
         }
     }
 

--- a/ad9959/src/lib.rs
+++ b/ad9959/src/lib.rs
@@ -559,7 +559,8 @@ impl ProfileSerializer {
     /// * `ftw` - If provided, indicates a frequency tuning word for the channels.
     /// * `pow` - If provided, indicates a phase offset word for the channels.
     /// * `acr` - If provided, indicates the amplitude control register for the channels. The ACR
-    ///   should be stored in the 3 LSB of the word.
+    ///   should be stored in the 3 LSB of the word. Note that if amplitude scaling is to be used,
+    ///   the "Amplitude multiplier enable" bit must be set.
     pub fn update_channels(
         &mut self,
         channels: &[Channel],

--- a/ad9959/src/lib.rs
+++ b/ad9959/src/lib.rs
@@ -582,7 +582,9 @@ impl ProfileSerializer {
         }
 
         if let Some(acr) = acr {
-            self.add_write(Register::ACR, &acr.to_be_bytes());
+            let mut data = [0; 3];
+            data[1..=2].copy_from_slice(&acr.to_be_bytes());
+            self.add_write(Register::ACR, &data);
         }
     }
 

--- a/src/hardware/pounder/dds_output.rs
+++ b/src/hardware/pounder/dds_output.rs
@@ -144,14 +144,15 @@ impl<'a> ProfileBuilder<'a> {
     /// * `channels` - A list of channels to apply the configuration to.
     /// * `ftw` - If provided, indicates a frequency tuning word for the channels.
     /// * `pow` - If provided, indicates a phase offset word for the channels.
-    /// * `acr` - If provided, indicates the amplitude control register for the channels.
+    /// * `acr` - If provided, indicates the amplitude control register for the channels. The
+    ///   24-bits of the ACR should be stored in the last 3 LSB.
     #[allow(dead_code)]
     pub fn update_channels(
         mut self,
         channels: &[Channel],
         ftw: Option<u32>,
         pow: Option<u16>,
-        acr: Option<u16>,
+        acr: Option<u32>,
     ) -> Self {
         self.serializer.update_channels(channels, ftw, pow, acr);
         self


### PR DESCRIPTION
This PR fixes #264 by properly assigning the ACR write to a 3 byte slice, which is equivalent to the size of the register in the AD9959.

A small number of other issues were uncovered and fixed in regard to the Pounder profile writer.

TODO:
- [x] Test ACR writes on pounder hardware

**Testing**
Verified that the FLS binary (not public) functioned with ACR updated to 99.9% amplied (1 less than FS).