### PR TITLE
Adding check wait for HITL

### DIFF
--- a/.github/workflows/hitl.yml
+++ b/.github/workflows/hitl.yml
@@ -17,8 +17,8 @@ jobs:
           repository: quartiq/hitl
           client-payload: '{"github": ${{ toJson(github) }}}'
 
-    - uses: fountainhead/action-wait-for-check@v1.0.0
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        checkName: HITL
-        ref: ${{ github.event.pull_request.head.sha }}
+      - uses: fountainhead/action-wait-for-check@v1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: HITL
+          ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/hitl.yml
+++ b/.github/workflows/hitl.yml
@@ -18,7 +18,7 @@ jobs:
           client-payload: '{"github": ${{ toJson(github) }}}'
 
       - name: Wait for startup
-        runs: sleep 30
+        run: sleep 30
 
       - uses: fountainhead/action-wait-for-check@v1.0.0
         with:

--- a/.github/workflows/hitl.yml
+++ b/.github/workflows/hitl.yml
@@ -1,4 +1,4 @@
-name: HITL
+name: HITL Run Request
 
 on:
   workflow_dispatch:

--- a/.github/workflows/hitl.yml
+++ b/.github/workflows/hitl.yml
@@ -16,3 +16,9 @@ jobs:
           event-type: stabilizer
           repository: quartiq/hitl
           client-payload: '{"github": ${{ toJson(github) }}}'
+
+    - uses: fountainhead/action-wait-for-check@v1.0.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        checkName: HITL
+        ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/hitl.yml
+++ b/.github/workflows/hitl.yml
@@ -17,6 +17,9 @@ jobs:
           repository: quartiq/hitl
           client-payload: '{"github": ${{ toJson(github) }}}'
 
+      - name: Wait for startup
+        runs: sleep 30
+
       - uses: fountainhead/action-wait-for-check@v1.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/hitl_trigger.yml
+++ b/.github/workflows/hitl_trigger.yml
@@ -1,4 +1,4 @@
-name: HITL Run Request
+name: HITL Trigger
 
 on:
   workflow_dispatch:

--- a/.github/workflows/hitl_trigger.yml
+++ b/.github/workflows/hitl_trigger.yml
@@ -6,7 +6,7 @@ on:
     branches: [ master ]
 
 jobs:
-  hitl:
+  hitl-trigger:
     runs-on: ubuntu-latest
     environment: hitl
     steps:

--- a/.github/workflows/hitl_trigger.yml
+++ b/.github/workflows/hitl_trigger.yml
@@ -23,5 +23,5 @@ jobs:
       - uses: fountainhead/action-wait-for-check@v1.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: HITL
+          checkName: HITL Run Status
           ref: ${{ github.event.pull_request.head.sha }}

--- a/hitl/run.sh
+++ b/hitl/run.sh
@@ -15,6 +15,8 @@ python3 -m venv --system-site-packages py
 . py/bin/activate
 python3 -m pip install -r requirements.txt
 
+cargo flash --bin dual-iir --release --chip STM32H743ZITx
+
 # Test pinging Stabilizer. This exercises that:
 # * DHCP is functional and an IP has been acquired
 # * Stabilizer's network is functioning as intended

--- a/hitl/run.sh
+++ b/hitl/run.sh
@@ -15,7 +15,7 @@ python3 -m venv --system-site-packages py
 . py/bin/activate
 python3 -m pip install -r requirements.txt
 
-cargo flash --bin dual-iir --release --chip STM32H743ZITx
+cargo flash --elf target/thumbv7em-none-eabihf/release/dual-iir --chip STM32H743ZITx
 
 # Test pinging Stabilizer. This exercises that:
 # * DHCP is functional and an IP has been acquired


### PR DESCRIPTION
This PR integrates the HITL into the PR check process - specifically, the HITL now posts a check onto the PR that we can require to pass.

This required the following:
1. Wait for the check to complete
2. Wait for a startup period (in case of re-starting check) so that a previously-passed check isn't detected in (1)