### PR TITLE
Updating badge to utilize nightly workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![QUARTIQ Matrix Chat](https://img.shields.io/matrix/quartiq:matrix.org)](https://matrix.to/#/#quartiq:matrix.org)
 [![Continuous Integration](https://github.com/quartiq/stabilizer/actions/workflows/ci.yml/badge.svg)](https://github.com/quartiq/stabilizer/actions/workflows/ci.yml)
-[![HITL (private)](https://github.com/quartiq/hitl/workflows/Stabilizer/badge.svg)](https://github.com/quartiq/hitl/actions?query=workflow%3AStabilizer)
+[![Stabilizer HITL [Nightly]](https://github.com/quartiq/hitl/actions/workflows/stabilizer-nightly.yml/badge.svg)](https://github.com/quartiq/hitl/actions/workflows/stabilizer-nightly.yml)
 
 # Stabilizer Firmware
 


### PR DESCRIPTION
This PR updates the HITL badge to use the nightly workflow. Using the triggered workflow results in the most recent run result from triggering PRs and does not reflect the real status of CI HITL testing.