### PR TITLE
Utilize unique MQTT prefix identifiers

### DIFF
--- a/hitl/run.sh
+++ b/hitl/run.sh
@@ -21,7 +21,7 @@ cargo flash --elf target/thumbv7em-none-eabihf/release/dual-iir --chip STM32H743
 # * DHCP is functional and an IP has been acquired
 # * Stabilizer's network is functioning as intended
 # * The stabilizer application is operational
-ping -c 5 -w 20 stabilizer-hitl
+ping -c 5 -w 45 stabilizer-hitl
 
 # Test the MQTT interface.
 python3 miniconf.py dt/sinara/stabilizer afe/0='"G2"'

--- a/hitl/run.sh
+++ b/hitl/run.sh
@@ -24,9 +24,9 @@ sleep 30
 # * DHCP is functional and an IP has been acquired
 # * Stabilizer's network is functioning as intended
 # * The stabilizer application is operational
-ping -c 5 -w 45 stabilizer-hitl
+ping -c 5 -w 20 stabilizer-hitl
 
 # Test the MQTT interface.
-python3 miniconf.py dt/sinara/stabilizer afe/0='"G2"'
-python3 miniconf.py dt/sinara/stabilizer afe/0='"G1"' iir_ch/0/0=\
+python3 miniconf.py dt/sinara/dual-iir/04-91-62-d9-7e-5f afe/0='"G2"'
+python3 miniconf.py dt/sinara/dual-iir/04-91-62-d9-7e-5f afe/0='"G1"' iir_ch/0/0=\
 '{"y_min": -32767, "y_max": 32767, "y_offset": 0, "ba": [1.0, 0, 0, 0, 0]}'

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -59,7 +59,10 @@ const APP: () = {
         let mqtt_settings = MqttSettings::new(
             stabilizer.net.stack,
             "",
-            "dt/sinara/stabilizer",
+            &net::get_device_prefix(
+                env!("CARGO_BIN_NAME"),
+                stabilizer.net.mac_address,
+            ),
             stabilizer.net.phy,
             stabilizer.cycle_counter,
         );

--- a/src/bin/lockin-external.rs
+++ b/src/bin/lockin-external.rs
@@ -8,6 +8,8 @@ use serde::Deserialize;
 
 use dsp::{Accu, Complex, ComplexExt, Lockin, RPLL};
 
+use stabilizer::net;
+
 use stabilizer::hardware::{
     design_parameters, setup, Adc0Input, Adc1Input, AfeGain, Dac0Output,
     Dac1Output, InputStamper, AFE0, AFE1,
@@ -74,7 +76,10 @@ const APP: () = {
         let mqtt_settings = MqttSettings::new(
             stabilizer.net.stack,
             "",
-            "dt/sinara/lockin",
+            &net::get_device_prefix(
+                env!("CARGO_BIN_NAME"),
+                stabilizer.net.mac_address,
+            ),
             stabilizer.net.phy,
             stabilizer.cycle_counter,
         );

--- a/src/hardware/configuration.rs
+++ b/src/hardware/configuration.rs
@@ -57,6 +57,7 @@ impl NetStorage {
 pub struct NetworkDevices {
     pub stack: NetworkStack,
     pub phy: EthernetPhy,
+    pub mac_address: smoltcp::wire::EthernetAddress,
 }
 
 /// The available hardware interfaces on Stabilizer.
@@ -544,7 +545,7 @@ pub fn setup(
             smoltcp::iface::NeighborCache::new(&mut store.neighbor_cache[..]);
 
         let interface = smoltcp::iface::EthernetInterfaceBuilder::new(eth_dma)
-            .ethernet_addr(mac_addr)
+            .ethernet_addr(mac_addr.clone())
             .neighbor_cache(neighbor_cache)
             .ip_addrs(&mut store.ip_addrs[..])
             .routes(routes)
@@ -599,6 +600,7 @@ pub fn setup(
                 Some(dhcp_client),
             ),
             phy: lan8742a,
+            mac_address: mac_addr,
         }
     };
 

--- a/src/hardware/configuration.rs
+++ b/src/hardware/configuration.rs
@@ -552,7 +552,7 @@ pub fn setup(
             smoltcp::iface::NeighborCache::new(&mut store.neighbor_cache[..]);
 
         let interface = smoltcp::iface::EthernetInterfaceBuilder::new(eth_dma)
-            .ethernet_addr(mac_addr.clone())
+            .ethernet_addr(mac_addr)
             .neighbor_cache(neighbor_cache)
             .ip_addrs(&mut store.ip_addrs[..])
             .routes(routes)

--- a/src/hardware/design_parameters.rs
+++ b/src/hardware/design_parameters.rs
@@ -51,4 +51,4 @@ pub const SAMPLE_BUFFER_SIZE_LOG2: u8 = 3;
 pub const SAMPLE_BUFFER_SIZE: usize = 1 << SAMPLE_BUFFER_SIZE_LOG2;
 
 // The MQTT broker IPv4 address
-pub const MQTT_BROKER: [u8; 4] = [10, 35, 16, 10];
+pub const MQTT_BROKER: [u8; 4] = [10, 34, 16, 10];

--- a/src/hardware/design_parameters.rs
+++ b/src/hardware/design_parameters.rs
@@ -51,4 +51,4 @@ pub const SAMPLE_BUFFER_SIZE_LOG2: u8 = 3;
 pub const SAMPLE_BUFFER_SIZE: usize = 1 << SAMPLE_BUFFER_SIZE_LOG2;
 
 // The MQTT broker IPv4 address
-pub const MQTT_BROKER: [u8; 4] = [10, 34, 16, 10];
+pub const MQTT_BROKER: [u8; 4] = [10, 35, 16, 10];

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2,6 +2,10 @@ use crate::hardware::{
     design_parameters::MQTT_BROKER, CycleCounter, EthernetPhy, NetworkStack,
 };
 
+use core::fmt::Write;
+
+use heapless::{consts, String};
+
 use miniconf::{minimq, MqttInterface};
 
 /// Potential actions for firmware to take.
@@ -105,4 +109,40 @@ where
             }
         }
     }
+}
+
+/// Get the MQTT prefix of a device.
+///
+/// # Args
+/// * `app` - The name of the application that is executing.
+/// * `mac` - The ethernet MAC address of the device.
+///
+/// # Returns
+/// The MQTT prefix used for this device.
+pub fn get_device_prefix(
+    app: &str,
+    mac: smoltcp_nal::smoltcp::wire::EthernetAddress,
+) -> String<consts::U128> {
+    let mac_string = {
+        let mut mac_string: String<consts::U32> = String::new();
+        let mac = mac.as_bytes();
+
+        // Note(unwrap): 32-bytes is guaranteed to be valid for any mac address, as the address has
+        // a fixed length.
+        write!(
+            &mut mac_string,
+            "{:02x}-{:02x}-{:02x}-{:02x}-{:02x}-{:02x}",
+            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+        )
+        .unwrap();
+
+        mac_string
+    };
+
+    // Note(unwrap): The mac address + binary name must be short enough to fit into this string. If
+    // they are defined too long, this will panic and the device will fail to boot.
+    let mut prefix: String<consts::U128> = String::new();
+    write!(&mut prefix, "dt/sinara/{}/{}", app, mac_string).unwrap();
+
+    prefix
 }


### PR DESCRIPTION
This PR addresses #276 by updating the API to utilize a default MQTT prefix calculated via the binary name and the MAC address.

In the future, this address will be persisted to flash bank 2 for persistence between flash operations and will be loaded on boot. It will also be configurable via MQTT.

This must be merged after https://github.com/quartiq/stabilizer/pull/314