### PR TITLE
hardware: add digital input support

### DIFF
--- a/dsp/benches/micro.rs
+++ b/dsp/benches/micro.rs
@@ -67,7 +67,7 @@ fn iir_bench() {
     let mut xy = iir::Vec5::default();
     println!(
         "int::IIR::update(s, x): {}",
-        bench_env(0.32241, |x| dut.update(&mut xy, *x))
+        bench_env(0.32241, |x| dut.update(&mut xy, *x, true))
     );
 }
 

--- a/dsp/src/iir.rs
+++ b/dsp/src/iir.rs
@@ -117,7 +117,7 @@ impl IIR {
     /// # Arguments
     /// * `xy` - Current filter state.
     /// * `x0` - New input.
-    pub fn update(&self, xy: &mut Vec5, x0: f32) -> f32 {
+    pub fn update(&self, xy: &mut Vec5, x0: f32, hold: bool) -> f32 {
         let n = self.ba.len();
         debug_assert!(xy.len() == n);
         // `xy` contains       x0 x1 y0 y1 y2
@@ -128,7 +128,11 @@ impl IIR {
         // Store x0            x0 x1 x2 y1 y2
         xy[0] = x0;
         // Compute y0 by multiply-accumulate
-        let y0 = macc(self.y_offset, xy, &self.ba);
+        let y0 = if hold {
+            xy[n / 2 + 1]
+        } else {
+            macc(self.y_offset, xy, &self.ba)
+        };
         // Limit y0
         let y0 = max(self.y_min, min(self.y_max, y0));
         // Store y0            x0 x1 y0 y1 y2

--- a/src/hardware/configuration.rs
+++ b/src/hardware/configuration.rs
@@ -9,7 +9,7 @@ use stm32h7xx_hal::{
 
 use smoltcp_nal::smoltcp;
 
-pub use embedded_hal::digital::v2::{InputPin, OutputPin};
+use embedded_hal::digital::v2::{InputPin, OutputPin};
 
 use super::{
     adc, afe, cycle_counter::CycleCounter, dac, design_parameters,

--- a/src/hardware/configuration.rs
+++ b/src/hardware/configuration.rs
@@ -9,12 +9,12 @@ use stm32h7xx_hal::{
 
 use smoltcp_nal::smoltcp;
 
-use embedded_hal::digital::v2::{InputPin, OutputPin};
+pub use embedded_hal::digital::v2::{InputPin, OutputPin};
 
 use super::{
     adc, afe, cycle_counter::CycleCounter, dac, design_parameters,
-    digital_input_stamper, eeprom, pounder, timers, DdsOutput, NetworkStack,
-    AFE0, AFE1,
+    digital_input_stamper, eeprom, pounder, timers, DdsOutput, DigitalInput0,
+    DigitalInput1, NetworkStack, AFE0, AFE1,
 };
 
 pub struct NetStorage {
@@ -69,6 +69,7 @@ pub struct StabilizerDevices {
     pub timestamp_timer: timers::TimestampTimer,
     pub net: NetworkDevices,
     pub cycle_counter: CycleCounter,
+    pub digital_inputs: (DigitalInput0, DigitalInput1),
 }
 
 /// The available Pounder-specific hardware interfaces.
@@ -437,6 +438,12 @@ pub fn setup(
             trigger,
             timestamp_timer_channels.ch4,
         )
+    };
+
+    let digital_inputs = {
+        let di0 = gpiog.pg9.into_floating_input();
+        let di1 = gpioc.pc15.into_floating_input();
+        (di0, di1)
     };
 
     let mut eeprom_i2c = {
@@ -872,6 +879,7 @@ pub fn setup(
         adc_dac_timer: sampling_timer,
         timestamp_timer,
         cycle_counter,
+        digital_inputs,
     };
 
     // info!("Version {} {}", build_info::PKG_VERSION, build_info::GIT_VERSION.unwrap());

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -1,6 +1,9 @@
 ///! Module for all hardware-specific setup of Stabilizer
 use stm32h7xx_hal as hal;
 
+// Re-export for the DigitalInputs below:
+pub use embedded_hal::digital::v2::InputPin;
+
 #[cfg(feature = "semihosting")]
 use panic_semihosting as _;
 

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -34,6 +34,14 @@ pub type AFE1 = afe::ProgrammableGainAmplifier<
     hal::gpio::gpiod::PD15<hal::gpio::Output<hal::gpio::PushPull>>,
 >;
 
+// Type alias for digital input 0 (DI0).
+pub type DigitalInput0 =
+    hal::gpio::gpiog::PG9<hal::gpio::Input<hal::gpio::Floating>>;
+
+// Type alias for digital input 1 (DI1).
+pub type DigitalInput1 =
+    hal::gpio::gpioc::PC15<hal::gpio::Input<hal::gpio::Floating>>;
+
 pub type NetworkStack = smoltcp_nal::NetworkStack<
     'static,
     'static,


### PR DESCRIPTION
* The inputs of the buffer are not pulled up/down. That might make them
  unusable if left floating. But since the hold feature is disabled via MQTT `allow_hold` by default, there is no regression.

close: #70 