### PR TITLE
TCP source port ranodmization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,7 +716,7 @@ dependencies = [
 [[package]]
 name = "smoltcp-nal"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/smoltcp-nal.git?branch=feature/random-port#b5b050b135f3fe89e1a33d7d9f1d3d8570132f3c"
+source = "git+https://github.com/quartiq/smoltcp-nal.git?rev=8468f11#8468f11abacd7aba82454e6904df19c1d1ab91bb"
 dependencies = [
  "embedded-nal",
  "heapless 0.6.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,7 +716,7 @@ dependencies = [
 [[package]]
 name = "smoltcp-nal"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/smoltcp-nal.git?branch=feature/random-port#462adc56a8cc95bc1324f6d96fdbe82e85ca6d36"
+source = "git+https://github.com/quartiq/smoltcp-nal.git?branch=feature/random-port#b5b050b135f3fe89e1a33d7d9f1d3d8570132f3c"
 dependencies = [
  "embedded-nal",
  "heapless 0.6.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,7 +710,7 @@ dependencies = [
 [[package]]
 name = "smoltcp-nal"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/smoltcp-nal.git?rev=d200d4e#d200d4eb20cdad42ed30a77f9c1690f43361d9e8"
+source = "git+https://github.com/quartiq/smoltcp-nal.git?rev=7572183#757218316620e074405bc38ff5502ef17a8a3499"
 dependencies = [
  "embedded-nal",
  "heapless 0.6.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanorand"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1378b66f7c93a1c0f8464a19bf47df8795083842e5090f4b7305973d5a22d0"
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,10 +716,11 @@ dependencies = [
 [[package]]
 name = "smoltcp-nal"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/smoltcp-nal.git?rev=7572183#757218316620e074405bc38ff5502ef17a8a3499"
+source = "git+https://github.com/quartiq/smoltcp-nal.git?branch=feature/random-port#462adc56a8cc95bc1324f6d96fdbe82e85ca6d36"
 dependencies = [
  "embedded-nal",
  "heapless 0.6.1",
+ "nanorand",
  "smoltcp",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ rev = "314fa5587d"
 
 [dependencies.smoltcp-nal]
 git = "https://github.com/quartiq/smoltcp-nal.git"
-branch = "feature/random-port"
+rev = "8468f11"
 
 [patch.crates-io.minimq]
 git = "https://github.com/quartiq/minimq.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ rev = "314fa5587d"
 
 [dependencies.smoltcp-nal]
 git = "https://github.com/quartiq/smoltcp-nal.git"
-rev = "7572183"
+branch = "feature/random-port"
 
 [patch.crates-io.minimq]
 git = "https://github.com/quartiq/minimq.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ rev = "314fa5587d"
 
 [dependencies.smoltcp-nal]
 git = "https://github.com/quartiq/smoltcp-nal.git"
-rev = "d200d4e"
+rev = "7572183"
 
 [patch.crates-io.minimq]
 git = "https://github.com/quartiq/minimq.git"

--- a/hitl/run.sh
+++ b/hitl/run.sh
@@ -17,11 +17,13 @@ python3 -m pip install -r requirements.txt
 
 cargo flash --elf target/thumbv7em-none-eabihf/release/dual-iir --chip STM32H743ZITx
 
+sleep 30
+
 # Test pinging Stabilizer. This exercises that:
 # * DHCP is functional and an IP has been acquired
 # * Stabilizer's network is functioning as intended
 # * The stabilizer application is operational
-ping -c 5 -w 20 stabilizer-hitl
+ping -c 5 -w 45 stabilizer-hitl
 
 # Test the MQTT interface.
 python3 miniconf.py dt/sinara/stabilizer afe/0='"G2"'

--- a/hitl/run.sh
+++ b/hitl/run.sh
@@ -17,13 +17,14 @@ python3 -m pip install -r requirements.txt
 
 cargo flash --elf target/thumbv7em-none-eabihf/release/dual-iir --chip STM32H743ZITx
 
+# Before attempting to ping the device, sleep to allow Stabilizer to boot.
 sleep 30
 
 # Test pinging Stabilizer. This exercises that:
 # * DHCP is functional and an IP has been acquired
 # * Stabilizer's network is functioning as intended
 # * The stabilizer application is operational
-ping -c 5 -w 45 stabilizer-hitl
+ping -c 5 -w 20 stabilizer-hitl
 
 # Test the MQTT interface.
 python3 miniconf.py dt/sinara/stabilizer afe/0='"G2"'

--- a/src/hardware/configuration.rs
+++ b/src/hardware/configuration.rs
@@ -594,13 +594,25 @@ pub fn setup(
             )
         };
 
+        let random_seed = {
+            let mut rng =
+                device.RNG.constrain(ccdr.peripheral.RNG, &ccdr.clocks);
+            let mut data = [0u8; 4];
+            rng.fill(&mut data).unwrap();
+            data
+        };
+
+        let mut stack = smoltcp_nal::NetworkStack::new(
+            interface,
+            sockets,
+            &handles,
+            Some(dhcp_client),
+        );
+
+        stack.seed_random_port(&random_seed);
+
         NetworkDevices {
-            stack: smoltcp_nal::NetworkStack::new(
-                interface,
-                sockets,
-                &handles,
-                Some(dhcp_client),
-            ),
+            stack,
             phy: lan8742a,
         }
     };


### PR DESCRIPTION
This PR adds support for randomizing the TCP port usage by the NAL. This helps to keep sockets flowing properly between resets.

## Testing

This branch was run numerous times on Stabilizer and Wireshark was used to observe traffic. It was observed that Stabilizer used different TCP ports in between each boot.