### PR TITLE
HITL Check Update

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,5 +1,6 @@
 block_labels = [ "S-blocked" ]
 delete_merged_branches = true
+timeout_sec = 1200
 status = [
   "style",
   "test (stable)",

--- a/.github/workflows/hitl_trigger.yml
+++ b/.github/workflows/hitl_trigger.yml
@@ -30,7 +30,7 @@ jobs:
           event-type: stabilizer
           repository: quartiq/hitl
           client-payload: |
-            '{"github": ${{ toJson(github) }}, "check_id": ${{steps.hitl-check.outputs.check_id}}}'
+            {"github": ${{ toJson(github) }}, "check_id": ${{steps.hitl-check.outputs.check_id}}}
 
       - uses: fountainhead/action-wait-for-check@v1.0.0
         with:

--- a/.github/workflows/hitl_trigger.yml
+++ b/.github/workflows/hitl_trigger.yml
@@ -12,15 +12,24 @@ jobs:
     runs-on: ubuntu-latest
     environment: hitl
     steps:
+      - uses: LouisBrunner/checks-action@v1.1.1
+        id: hitl-check
+        with:
+          repo: ${{ github.repository }}
+          sha: ${{ github.event.head_commit.id }}
+          token: ${{ github.token }}
+          name: HITL Run Status
+          status: in_progress
+          details_url: "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
+          output: { "summary": "Starting..." }
+
       - uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.DISPATCH_PAT }}
           event-type: stabilizer
           repository: quartiq/hitl
-          client-payload: '{"github": ${{ toJson(github) }}}'
-
-      - name: Wait for startup
-        run: sleep 30
+          client-payload: |
+            '{"github": ${{ toJson(github) }}, "check_id": ${{steps.hitl-check.outputs.check_id}}}'
 
       - uses: fountainhead/action-wait-for-check@v1.0.0
         with:

--- a/.github/workflows/hitl_trigger.yml
+++ b/.github/workflows/hitl_trigger.yml
@@ -21,7 +21,8 @@ jobs:
           name: HITL Run Status
           status: in_progress
           details_url: "https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
-          output: { "summary": "Starting..." }
+          output: |
+            {"summary": "Starting..."}
 
       - uses: peter-evans/repository-dispatch@v1
         with:


### PR DESCRIPTION
Updating the HITL workflow to create the check locally before having the remote repository create it. This makes it belong to a deterministic test suite and always exist