### PR TITLE
Adding basic task timing telemetry

### DIFF
--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -15,6 +15,9 @@ mod eeprom;
 pub mod pounder;
 mod system_timer;
 mod timers;
+mod task_timer;
+
+pub use task_timer::{TaskInfo, TaskTimer};
 
 pub use adc::{Adc0Input, Adc1Input, AdcCode};
 pub use afe::Gain as AfeGain;

--- a/src/hardware/task_timer.rs
+++ b/src/hardware/task_timer.rs
@@ -1,0 +1,62 @@
+use serde::Serialize;
+
+pub struct TaskTimer {
+    // With a 400MHz CPU, total ticks will overflow after ~1500 years.
+    total_ticks: u64,
+    executions: u32,
+    start_tick: Option<u32>,
+}
+
+#[derive(Serialize)]
+pub struct TaskInfo {
+    duration_avg: f32,
+    count: u32,
+}
+
+impl TaskTimer {
+    pub fn new() -> Self {
+        Self {
+            total_ticks: 0,
+            executions: 0,
+            start_tick: None,
+        }
+    }
+
+    fn get_time() -> u32 {
+        cortex_m::peripheral::DWT::get_cycle_count()
+    }
+
+    pub fn enter(&mut self) {
+        let now = Self::get_time();
+        self.start_tick.replace(now);
+    }
+
+    pub fn exit(&mut self) {
+        let now = Self::get_time();
+
+        // Note(unwrap): exit() must be called exactly once after `enter()`.
+        let start = self.start_tick.take().unwrap();
+
+        // Note(wrapping_sub): We can only measure durations up to the period of the underlying
+        // timer. We cannot detect timer overflows.
+        let duration = now.wrapping_sub(start);
+
+        self.total_ticks += duration as u64;
+        self.executions += 1;
+    }
+
+    pub fn get_info(&self, clock_frequency: f32) -> TaskInfo {
+        let tick_period = 1.0 / clock_frequency;
+
+        let average_ticks = if self.executions == 0 {
+            0
+        } else {
+            self.total_ticks / (self.executions as u64)
+        };
+
+        TaskInfo {
+            duration_avg: average_ticks as f32 * tick_period,
+            count: self.executions,
+        }
+    }
+}

--- a/src/net/telemetry.rs
+++ b/src/net/telemetry.rs
@@ -21,7 +21,7 @@ use crate::hardware::{
 
 /// The telemetry client for reporting telemetry data over MQTT.
 pub struct TelemetryClient<T: Serialize> {
-    mqtt: minimq::MqttClient<minimq::consts::U256, NetworkReference>,
+    mqtt: minimq::MqttClient<minimq::consts::U512, NetworkReference>,
     telemetry_topic: String<consts::U128>,
     _telemetry: core::marker::PhantomData<T>,
 }
@@ -119,11 +119,14 @@ impl<T: Serialize> TelemetryClient<T> {
     /// # Args
     /// * `telemetry` - The telemetry to report
     pub fn publish(&mut self, telemetry: &T) {
-        let telemetry: Vec<u8, consts::U256> =
+        let telemetry: Vec<u8, consts::U512> =
             serde_json_core::to_vec(telemetry).unwrap();
-        self.mqtt
-            .publish(&self.telemetry_topic, &telemetry, QoS::AtMostOnce, &[])
-            .ok();
+        let result = self.mqtt
+            .publish(&self.telemetry_topic, &telemetry, QoS::AtMostOnce, &[]);
+
+        if result.is_err() {
+            log::warn!("Telemetry failure: {:?}", result);
+        }
     }
 
     /// Update the telemetry client


### PR DESCRIPTION
This PR addresses #166 by adding some basic timers to the various tasks.

This is a minimalistic implementation so that I could get a guage as to how long tasks were taking, so it's not really considered complete.

Ideally:
* This could be integrated into RTIC
* Lower the serialization overhead required here
* We utilize the `SystemTimer` to calculate average load of each task