### PR TITLE
dma: don't swap buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,7 +810,7 @@ dependencies = [
 [[package]]
 name = "stm32h7xx-hal"
 version = "0.9.0"
-source = "git+https://github.com/quartiq/stm32h7xx-hal.git?rev=cca4ecc#cca4ecc3e0cc8cb2f7a9652c4099d50b44977493"
+source = "git+https://github.com/quartiq/stm32h7xx-hal.git?rev=b0b8a93#b0b8a930b2c3bc5fcebc2e905b4c5e13360111a5"
 dependencies = [
  "bare-metal 1.0.0",
  "cast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,8 +802,7 @@ dependencies = [
 [[package]]
 name = "stm32h7xx-hal"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67034b80041bc33a48df1c1c435b6ae3bb18c35e42aa7e702ce8363b96793398"
+source = "git+https://github.com/quartiq/stm32h7xx-hal.git?rev=cca4ecc#cca4ecc3e0cc8cb2f7a9652c4099d50b44977493"
 dependencies = [
  "bare-metal 1.0.0",
  "cast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,9 @@ rev = "523d71d"
 
 [dependencies.stm32h7xx-hal]
 features = ["stm32h743v", "rt", "unproven", "ethernet", "quadspi"]
-version = "0.9.0"
+# version = "0.9.0"
+git = "https://github.com/quartiq/stm32h7xx-hal.git"
+rev = "cca4ecc"
 
 [patch.crates-io.miniconf]
 git = "https://github.com/quartiq/miniconf.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,11 +52,12 @@ mcp23017 = "1.0"
 git = "https://github.com/quartiq/rtt-logger.git"
 rev = "70b0eb5"
 
+# fast double buffered DMA without poisoning and buffer swapping
 [dependencies.stm32h7xx-hal]
 features = ["stm32h743v", "rt", "unproven", "ethernet", "quadspi"]
 # version = "0.9.0"
 git = "https://github.com/quartiq/stm32h7xx-hal.git"
-rev = "cca4ecc"
+rev = "b0b8a93"
 
 # link.x section start/end
 [patch.crates-io.cortex-m-rt]

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -54,10 +54,10 @@ impl Default for Settings {
 
 macro_rules! flatten_closures {
     ($fn:ident, $e:ident, $fun:block) => {
-        $e.$fn(|$e| $fun )
+        $e.$fn(|$e| $fun ).unwrap()
     };
     ($fn:ident, $e:ident, $($es:ident),+, $fun:block) => {
-        $e.$fn(|$e| flatten_closures!($fn, $($es),*, $fun))
+        $e.$fn(|$e| flatten_closures!($fn, $($es),*, $fun)).unwrap()
     };
 }
 

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -4,7 +4,7 @@
 
 use core::sync::atomic::{fence, Ordering};
 
-use stabilizer::{hardware, net};
+use stabilizer::{flatten_closures, hardware, net};
 
 use miniconf::Miniconf;
 use serde::Deserialize;
@@ -50,15 +50,6 @@ impl Default for Settings {
             telemetry_period: 10,
         }
     }
-}
-
-macro_rules! flatten_closures {
-    ($fn:ident, $e:ident, $fun:block) => {
-        $e.$fn(|$e| $fun ).unwrap()
-    };
-    ($fn:ident, $e:ident, $($es:ident),+, $fun:block) => {
-        $e.$fn(|$e| flatten_closures!($fn, $($es),*, $fun)).unwrap()
-    };
 }
 
 #[rtic::app(device = stm32h7xx_hal::stm32, peripherals = true, monotonic = stabilizer::hardware::SystemTimer)]

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -238,22 +238,22 @@ const APP: () = {
 
     #[task(binds = SPI2, priority = 3)]
     fn spi2(_: spi2::Context) {
-        panic!("ADC0 input overrun");
+        panic!("ADC0 SPI error");
     }
 
     #[task(binds = SPI3, priority = 3)]
     fn spi3(_: spi3::Context) {
-        panic!("ADC1 input overrun");
+        panic!("ADC1 SPI error");
     }
 
     #[task(binds = SPI4, priority = 3)]
     fn spi4(_: spi4::Context) {
-        panic!("DAC0 output error");
+        panic!("DAC0 SPI error");
     }
 
     #[task(binds = SPI5, priority = 3)]
     fn spi5(_: spi5::Context) {
-        panic!("DAC1 output error");
+        panic!("DAC1 SPI error");
     }
 
     extern "C" {

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -2,6 +2,8 @@
 #![no_std]
 #![no_main]
 
+use core::sync::atomic::{fence, Ordering};
+
 use embedded_hal::digital::v2::InputPin;
 
 use serde::Deserialize;
@@ -214,6 +216,9 @@ const APP: () = {
             let adc_samples = [adc0, adc1];
             let mut dac_samples = [dac0, dac1];
 
+            // Preserve instruction and data ordering w.r.t. DMA flag access.
+            fence(Ordering::SeqCst);
+
             let output: Complex<i32> = adc_samples[0]
                 .iter()
                 // Zip in the LO phase.
@@ -252,6 +257,9 @@ const APP: () = {
 
             telemetry.dacs =
                 [DacCode(dac_samples[0][0]), DacCode(dac_samples[1][0])];
+
+            // Preserve instruction and data ordering w.r.t. DMA flag access.
+            fence(Ordering::SeqCst);
         });
     }
 

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -313,22 +313,22 @@ const APP: () = {
 
     #[task(binds = SPI2, priority = 3)]
     fn spi2(_: spi2::Context) {
-        panic!("ADC0 input overrun");
+        panic!("ADC0 SPI error");
     }
 
     #[task(binds = SPI3, priority = 3)]
     fn spi3(_: spi3::Context) {
-        panic!("ADC1 input overrun");
+        panic!("ADC1 SPI error");
     }
 
     #[task(binds = SPI4, priority = 3)]
     fn spi4(_: spi4::Context) {
-        panic!("DAC0 output error");
+        panic!("DAC0 SPI error");
     }
 
     #[task(binds = SPI5, priority = 3)]
     fn spi5(_: spi5::Context) {
-        panic!("DAC1 output error");
+        panic!("DAC1 SPI error");
     }
 
     extern "C" {

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -10,9 +10,9 @@ use serde::Deserialize;
 
 use dsp::{Accu, Complex, ComplexExt, Lockin, RPLL};
 
-use stabilizer::net;
+use stabilizer::{flatten_closures, hardware, net};
 
-use stabilizer::hardware::{
+use hardware::{
     design_parameters, setup, Adc0Input, Adc1Input, AdcCode, AfeGain,
     Dac0Output, Dac1Output, DacCode, DigitalInput0, DigitalInput1,
     InputStamper, SystemTimer, AFE0, AFE1,
@@ -78,15 +78,6 @@ impl Default for Settings {
             telemetry_period: 10,
         }
     }
-}
-
-macro_rules! flatten_closures {
-    ($fn:ident, $e:ident, $fun:block) => {
-        $e.$fn(|$e| $fun ).unwrap()
-    };
-    ($fn:ident, $e:ident, $($es:ident),+, $fun:block) => {
-        $e.$fn(|$e| flatten_closures!($fn, $($es),*, $fun)).unwrap()
-    };
 }
 
 #[rtic::app(device = stm32h7xx_hal::stm32, peripherals = true, monotonic = stabilizer::hardware::SystemTimer)]

--- a/src/hardware/adc.rs
+++ b/src/hardware/adc.rs
@@ -81,6 +81,7 @@ use hal::dma::{
 #[derive(Copy, Clone)]
 pub struct AdcCode(pub u16);
 
+#[allow(clippy::from_over_into)]
 impl Into<f32> for AdcCode {
     /// Convert raw ADC codes to/from voltage levels.
     ///

--- a/src/hardware/adc.rs
+++ b/src/hardware/adc.rs
@@ -74,7 +74,7 @@ use hal::dma::{
     config::Priority,
     dma::{DMAReq, DmaConfig},
     traits::TargetAddress,
-    MemoryToPeripheral, PeripheralToMemory, Transfer,
+    DMAError, MemoryToPeripheral, PeripheralToMemory, Transfer,
 };
 
 /// A type representing an ADC sample.
@@ -359,7 +359,7 @@ macro_rules! adc_input {
                 ///
                 /// NOTE(unsafe): Memory safety and access ordering is not guaranteed
                 /// (see the HAL DMA docs).
-                pub fn with_buffer<F, R>(&mut self, f: F) -> R
+                pub fn with_buffer<F, R>(&mut self, f: F) -> Result<R, DMAError>
                     where
                 F: FnOnce(&mut SampleBuffer) -> R,
                 {

--- a/src/hardware/configuration.rs
+++ b/src/hardware/configuration.rs
@@ -233,6 +233,11 @@ pub fn setup(
     let dma_streams =
         hal::dma::dma::StreamsTuple::new(device.DMA1, ccdr.peripheral.DMA1);
 
+    // Early, before the DMA1 peripherals (#272)
+    #[cfg(feature = "pounder_v1_1")]
+    let dma2_streams =
+        hal::dma::dma::StreamsTuple::new(device.DMA2, ccdr.peripheral.DMA2);
+
     // Configure timer 2 to trigger conversions for the ADC
     let mut sampling_timer = {
         // The timer frequency is manually adjusted below, so the 1KHz setting here is a
@@ -941,6 +946,7 @@ pub fn setup(
 
             pounder::timestamp::Timestamper::new(
                 timestamp_timer,
+                dma2_streams.0,
                 tim8_channels.ch1,
                 &mut sampling_timer,
                 etr_pin,

--- a/src/hardware/configuration.rs
+++ b/src/hardware/configuration.rs
@@ -233,11 +233,6 @@ pub fn setup(
     let dma_streams =
         hal::dma::dma::StreamsTuple::new(device.DMA1, ccdr.peripheral.DMA1);
 
-    // Early, before the DMA1 peripherals (#272)
-    #[cfg(feature = "pounder_v1_1")]
-    let dma2_streams =
-        hal::dma::dma::StreamsTuple::new(device.DMA2, ccdr.peripheral.DMA2);
-
     // Configure timer 2 to trigger conversions for the ADC
     let mut sampling_timer = {
         // The timer frequency is manually adjusted below, so the 1KHz setting here is a
@@ -946,7 +941,6 @@ pub fn setup(
 
             pounder::timestamp::Timestamper::new(
                 timestamp_timer,
-                dma2_streams.0,
                 tim8_channels.ch1,
                 &mut sampling_timer,
                 etr_pin,

--- a/src/hardware/dac.rs
+++ b/src/hardware/dac.rs
@@ -73,6 +73,7 @@ static mut DAC_BUF: [[SampleBuffer; 2]; 2] = [[[0; SAMPLE_BUFFER_SIZE]; 2]; 2];
 #[derive(Copy, Clone)]
 pub struct DacCode(pub u16);
 
+#[allow(clippy::from_over_into)]
 impl Into<f32> for DacCode {
     fn into(self) -> f32 {
         // The DAC output range in bipolar mode (including the external output op-amp) is +/- 4.096
@@ -104,7 +105,7 @@ macro_rules! dac_output {
                 _channel: timers::tim2::$trigger_channel,
                 spi: hal::spi::Spi<hal::stm32::$spi, hal::spi::Disabled, u16>,
             ) -> Self {
-                Self { _channel, spi }
+                Self { spi, _channel }
             }
 
             /// Start the SPI and begin operating in a DMA-driven transfer mode.

--- a/src/hardware/dac.rs
+++ b/src/hardware/dac.rs
@@ -58,7 +58,7 @@ use super::timers;
 use hal::dma::{
     dma::{DMAReq, DmaConfig},
     traits::TargetAddress,
-    MemoryToPeripheral, Transfer,
+    DMAError, MemoryToPeripheral, Transfer,
 };
 
 // The following global buffers are used for the DAC code DMA transfers. Two buffers are used for
@@ -209,7 +209,7 @@ macro_rules! dac_output {
             ///
             /// NOTE(unsafe): Memory safety and access ordering is not guaranteed
             /// (see the HAL DMA docs).
-            pub fn with_buffer<F, R>(&mut self, f: F) -> R
+            pub fn with_buffer<F, R>(&mut self, f: F) -> Result<R, DMAError>
             where
                 F: FnOnce(&mut SampleBuffer) -> R,
             {

--- a/src/hardware/dac.rs
+++ b/src/hardware/dac.rs
@@ -52,7 +52,7 @@
 ///! served promptly after the transfer completes.
 use stm32h7xx_hal as hal;
 
-use super::design_parameters::SAMPLE_BUFFER_SIZE;
+use super::design_parameters::{SampleBuffer, SAMPLE_BUFFER_SIZE};
 use super::timers;
 
 use hal::dma::{
@@ -66,8 +66,7 @@ use hal::dma::{
 // processed). Note that the contents of AXI SRAM is uninitialized, so the buffer contents on
 // startup are undefined. The dimensions are `ADC_BUF[adc_index][ping_pong_index][sample_index]`.
 #[link_section = ".axisram.buffers"]
-static mut DAC_BUF: [[[u16; SAMPLE_BUFFER_SIZE]; 3]; 2] =
-    [[[0; SAMPLE_BUFFER_SIZE]; 3]; 2];
+static mut DAC_BUF: [[SampleBuffer; 2]; 2] = [[[0; SAMPLE_BUFFER_SIZE]; 2]; 2];
 
 /// Custom type for referencing DAC output codes.
 /// The internal integer is the raw code written to the DAC output register.
@@ -137,13 +136,12 @@ macro_rules! dac_output {
 
         /// Represents data associated with DAC.
         pub struct $name {
-            next_buffer: Option<&'static mut [u16; SAMPLE_BUFFER_SIZE]>,
             // Note: SPI TX functionality may not be used from this structure to ensure safety with DMA.
             transfer: Transfer<
                 hal::dma::dma::$data_stream<hal::stm32::DMA1>,
                 $spi,
                 MemoryToPeripheral,
-                &'static mut [u16; SAMPLE_BUFFER_SIZE],
+                &'static mut SampleBuffer,
                 hal::dma::DBTransfer,
             >,
         }
@@ -198,33 +196,26 @@ macro_rules! dac_output {
                         trigger_config,
                     );
 
-                Self {
-                    transfer,
-                    // Note(unsafe): This buffer is only used once and provided for the next DMA transfer.
-                    next_buffer: unsafe { Some(&mut DAC_BUF[$index][2]) },
-                }
+                Self { transfer }
             }
 
             pub fn start(&mut self) {
                 self.transfer.start(|spi| spi.start_dma());
             }
 
-            /// Acquire the next output buffer to populate it with DAC codes.
-            pub fn acquire_buffer(&mut self) -> &mut [u16; SAMPLE_BUFFER_SIZE] {
-                // Note: If a device hangs up, check that this conditional is passing correctly, as
-                // there is no time-out checks here in the interest of execution speed.
-                while !self.transfer.get_transfer_complete_flag() {}
-
-                let next_buffer = self.next_buffer.take().unwrap();
-
-                // Start the next transfer.
-                let (prev_buffer, _, _) =
-                    self.transfer.next_transfer(next_buffer).unwrap();
-
-                // .unwrap_none() https://github.com/rust-lang/rust/issues/62633
-                self.next_buffer.replace(prev_buffer);
-
-                self.next_buffer.as_mut().unwrap()
+            /// Wait for the transfer of the currently active buffer to complete,
+            /// then call a function on the now inactive buffer and acknowledge the
+            /// transfer complete flag.
+            ///
+            /// NOTE(unsafe): Memory safety and access ordering is not guaranteed
+            /// (see the HAL DMA docs).
+            pub fn with_buffer<F, R>(&mut self, f: F) -> R
+            where
+                F: FnOnce(&mut SampleBuffer) -> R,
+            {
+                unsafe {
+                    self.transfer.next_dbm_transfer_with(|buf, _current| f(buf))
+                }
             }
         }
     };

--- a/src/hardware/design_parameters.rs
+++ b/src/hardware/design_parameters.rs
@@ -50,5 +50,7 @@ pub const ADC_SAMPLE_TICKS: u16 = 1 << ADC_SAMPLE_TICKS_LOG2;
 pub const SAMPLE_BUFFER_SIZE_LOG2: u8 = 3;
 pub const SAMPLE_BUFFER_SIZE: usize = 1 << SAMPLE_BUFFER_SIZE_LOG2;
 
+pub type SampleBuffer = [u16; SAMPLE_BUFFER_SIZE];
+
 // The MQTT broker IPv4 address
 pub const MQTT_BROKER: [u8; 4] = [10, 34, 16, 10];

--- a/src/hardware/pounder/dds_output.rs
+++ b/src/hardware/pounder/dds_output.rs
@@ -52,9 +52,11 @@
 ///! compile-time-known register update sequence needed for the application, the serialization
 ///! process can be done once and then register values can be written into a pre-computed serialized
 ///! buffer to avoid the software overhead of much of the serialization process.
+use log::warn;
+use stm32h7xx_hal as hal;
+
 use super::{hrtimer::HighResTimerE, QspiInterface};
 use ad9959::{Channel, DdsConfig, ProfileSerializer};
-use stm32h7xx_hal as hal;
 
 /// The DDS profile update stream.
 pub struct DdsOutput {

--- a/src/hardware/pounder/timestamp.rs
+++ b/src/hardware/pounder/timestamp.rs
@@ -24,27 +24,12 @@
 ///! schedule.
 use stm32h7xx_hal as hal;
 
-use hal::dma::{dma::DmaConfig, PeripheralToMemory, Transfer};
-
-use crate::hardware::{design_parameters::SAMPLE_BUFFER_SIZE, timers};
-
-// Three buffers are required for double buffered mode - 2 are owned by the DMA stream and 1 is the
-// working data provided to the application. These buffers must exist in a DMA-accessible memory
-// region. Note that AXISRAM is not initialized on boot, so their initial contents are undefined.
-#[link_section = ".axisram.buffers"]
-static mut BUF: [[u16; SAMPLE_BUFFER_SIZE]; 3] = [[0; SAMPLE_BUFFER_SIZE]; 3];
+use crate::hardware::timers;
 
 /// Software unit to timestamp stabilizer ADC samples using an external pounder reference clock.
 pub struct Timestamper {
-    next_buffer: Option<&'static mut [u16; SAMPLE_BUFFER_SIZE]>,
     timer: timers::PounderTimestampTimer,
-    transfer: Transfer<
-        hal::dma::dma::Stream0<hal::stm32::DMA2>,
-        timers::tim8::Channel1InputCapture,
-        PeripheralToMemory,
-        &'static mut [u16; SAMPLE_BUFFER_SIZE],
-        hal::dma::DBTransfer,
-    >,
+    capture_channel: timers::tim8::Channel1InputCapture,
 }
 
 impl Timestamper {
@@ -65,18 +50,12 @@ impl Timestamper {
     /// The new pounder timestamper in an operational state.
     pub fn new(
         mut timestamp_timer: timers::PounderTimestampTimer,
-        stream: hal::dma::dma::Stream0<hal::stm32::DMA2>,
         capture_channel: timers::tim8::Channel1,
         sampling_timer: &mut timers::SamplingTimer,
         _clock_input: hal::gpio::gpioa::PA0<
             hal::gpio::Alternate<hal::gpio::AF3>,
         >,
     ) -> Self {
-        let config = DmaConfig::default()
-            .memory_increment(true)
-            .circular_buffer(true)
-            .double_buffer(true);
-
         // The sampling timer should generate a trigger output when CH1 comparison occurs.
         sampling_timer.generate_trigger(timers::TriggerGenerator::ComparePulse);
 
@@ -87,62 +66,29 @@ impl Timestamper {
         // The capture channel should capture whenever the trigger input occurs.
         let input_capture = capture_channel
             .into_input_capture(timers::tim8::CaptureSource1::TRC);
-        input_capture.listen_dma();
-
-        // The data transfer is always a transfer of data from the peripheral to a RAM buffer.
-        let data_transfer: Transfer<_, _, PeripheralToMemory, _, _> =
-            Transfer::init(
-                stream,
-                input_capture,
-                // Note(unsafe): BUF[0] and BUF[1] are "owned" by this peripheral.
-                // They shall not be used anywhere else in the module.
-                unsafe { &mut BUF[0] },
-                unsafe { Some(&mut BUF[1]) },
-                config,
-            );
 
         Self {
             timer: timestamp_timer,
-            transfer: data_transfer,
-
-            // Note(unsafe): BUF[2] is "owned" by this peripheral. It shall not be used anywhere
-            // else in the module.
-            next_buffer: unsafe { Some(&mut BUF[2]) },
+            capture_channel: input_capture,
         }
     }
 
-    /// Start the DMA transfer for collecting timestamps.
-    #[allow(dead_code)]
+    /// Start collecting timestamps.
     pub fn start(&mut self) {
-        self.transfer
-            .start(|capture_channel| capture_channel.enable());
+        self.capture_channel.enable();
     }
 
     /// Update the period of the underlying timestamp timer.
-    #[allow(dead_code)]
     pub fn update_period(&mut self, period: u16) {
         self.timer.set_period_ticks(period);
     }
 
-    /// Obtain a buffer filled with timestamps.
+    /// Obtain a timestamp.
     ///
     /// # Returns
-    /// A reference to the underlying buffer that has been filled with timestamps.
-    #[allow(dead_code)]
-    pub fn acquire_buffer(&mut self) -> &[u16; SAMPLE_BUFFER_SIZE] {
-        // Wait for the transfer to fully complete before continuing.
-        // Note: If a device hangs up, check that this conditional is passing correctly, as there is
-        // no time-out checks here in the interest of execution speed.
-        while !self.transfer.get_transfer_complete_flag() {}
-
-        let next_buffer = self.next_buffer.take().unwrap();
-
-        // Start the next transfer.
-        let (prev_buffer, _, _) =
-            self.transfer.next_transfer(next_buffer).unwrap();
-
-        self.next_buffer.replace(prev_buffer); // .unwrap_none() https://github.com/rust-lang/rust/issues/62633
-
-        self.next_buffer.as_ref().unwrap()
+    /// A `Result` potentially indicating capture overflow and containing a `Option` of a captured
+    /// timestamp.
+    pub fn latest_timestamp(&mut self) -> Result<Option<u16>, Option<u16>> {
+        self.capture_channel.latest_capture()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 #![cfg_attr(feature = "nightly", feature(core_intrinsics))]
 
-#[macro_use]
-extern crate log;
-
 pub mod hardware;
 pub mod net;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,16 @@
 
 pub mod hardware;
 pub mod net;
+
+/// Macro to reduce rightward drift when calling the same closure-based API
+/// on multiple structs simultaneously, e.g. when accessing DMA buffers.
+/// This could be improved a bit using the tuple-based style from `mutex-trait`.
+#[macro_export]
+macro_rules! flatten_closures {
+    ($fn:ident, $e:ident, $fun:block) => {
+        $e.$fn(|$e| $fun ).unwrap()
+    };
+    ($fn:ident, $e:ident, $($es:ident),+, $fun:block) => {
+        $e.$fn(|$e| flatten_closures!($fn, $($es),*, $fun)).unwrap()
+    };
+}

--- a/src/net/miniconf_client.rs
+++ b/src/net/miniconf_client.rs
@@ -119,7 +119,6 @@ where
                 .string_set(path.split('/').peekable(), message)
                 .map(|_| {
                     update = true;
-                    ()
                 })
                 .into();
 

--- a/src/net/miniconf_client.rs
+++ b/src/net/miniconf_client.rs
@@ -103,7 +103,7 @@ where
             let path = match topic.strip_prefix(prefix) {
                 // For paths, we do not want to include the leading slash.
                 Some(path) => {
-                    if path.len() > 0 {
+                    if !path.is_empty() {
                         &path[1..]
                     } else {
                         path
@@ -117,9 +117,9 @@ where
 
             let message: SettingsResponse = settings
                 .string_set(path.split('/').peekable(), message)
-                .and_then(|_| {
+                .map(|_| {
                     update = true;
-                    Ok(())
+                    ()
                 })
                 .into();
 

--- a/src/net/miniconf_client.rs
+++ b/src/net/miniconf_client.rs
@@ -11,6 +11,7 @@
 ///! Respones to settings updates are sent without quality-of-service guarantees, so there's no
 ///! guarantee that the requestee will be informed that settings have been applied.
 use heapless::String;
+use log::info;
 
 use super::{MqttMessage, NetworkReference, SettingsResponse, UpdateState};
 use crate::hardware::design_parameters::MQTT_BROKER;


### PR DESCRIPTION
* This uses a new closure-based method to the DMA HAL implementation which
  gives access to the inactive buffer directly.
* It removes changing addresses, the third buffer for DBM, the inactive
  address poisoning, and allows the cancellation of the redundant repeat
  memory barriers and compiler fences.
* This is now around 20 instructions per buffer down from about 100 cycles
  before.
* Also introduces a new `SampleBuffer` type alias.
* The required unpacking of the resources structure is a bit annoying
  but could probably abstraced away.
* Reduced pounder capture rate to the batch rate using the prescaler.
* Removes the Pounder Timestamper DMA (close #260)

TODO:

* [x] Tested that dual-iir still works
* [x] Tested that DMA overflows are signaled as panics (batch size 1 at full rate)
* [x] Adapt `lockin`
* [x] Tested on FLS without pounder timestamp DMA.