### PR TITLE
Removing spurious settings updates

### DIFF
--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -13,7 +13,7 @@ use hardware::{
     DigitalInput0, DigitalInput1, InputPin, SystemTimer, AFE0, AFE1,
 };
 
-use net::{NetworkUsers, Telemetry, TelemetryBuffer, UpdateState};
+use net::{NetworkState, NetworkUsers, Telemetry, TelemetryBuffer};
 
 const SCALE: f32 = i16::MAX as _;
 
@@ -171,8 +171,11 @@ const APP: () = {
     fn idle(mut c: idle::Context) -> ! {
         loop {
             match c.resources.network.lock(|net| net.update()) {
-                UpdateState::Updated => c.spawn.settings_update().unwrap(),
-                UpdateState::NoChange => cortex_m::asm::wfi(),
+                NetworkState::SettingsChanged => {
+                    c.spawn.settings_update().unwrap()
+                }
+                NetworkState::Updated => {}
+                NetworkState::NoChange => cortex_m::asm::wfi(),
             }
         }
     }

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -17,7 +17,7 @@ use stabilizer::hardware::{
 };
 
 use miniconf::Miniconf;
-use net::{NetworkUsers, Telemetry, TelemetryBuffer, UpdateState};
+use net::{NetworkState, NetworkUsers, Telemetry, TelemetryBuffer};
 
 // A constant sinusoid to send on the DAC output.
 // Full-scale gives a +/- 10.24V amplitude waveform. Scale it down to give +/- 1V.
@@ -248,8 +248,11 @@ const APP: () = {
     fn idle(mut c: idle::Context) -> ! {
         loop {
             match c.resources.network.lock(|net| net.update()) {
-                UpdateState::Updated => c.spawn.settings_update().unwrap(),
-                UpdateState::NoChange => cortex_m::asm::wfi(),
+                NetworkState::SettingsChanged => {
+                    c.spawn.settings_update().unwrap()
+                }
+                NetworkState::Updated => {}
+                NetworkState::NoChange => cortex_m::asm::wfi(),
             }
         }
     }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -33,6 +33,12 @@ pub enum UpdateState {
     Updated,
 }
 
+#[derive(Copy, Clone, PartialEq)]
+pub enum NetworkState {
+    SettingsChanged,
+    Updated,
+    NoChange,
+}
 /// A structure of Stabilizer's default network users.
 pub struct NetworkUsers<S: Default + Clone + Miniconf, T: Serialize> {
     pub miniconf: MiniconfClient<S>,
@@ -98,15 +104,18 @@ where
     ///
     /// # Returns
     /// An indication if any of the network users indicated a state change.
-    pub fn update(&mut self) -> UpdateState {
+    pub fn update(&mut self) -> NetworkState {
         // Poll for incoming data.
-        let poll_result = self.processor.update();
+        let poll_result = match self.processor.update() {
+            UpdateState::NoChange => NetworkState::NoChange,
+            UpdateState::Updated => NetworkState::Updated,
+        };
 
         // Update the MQTT clients.
         self.telemetry.update();
 
         match self.miniconf.update() {
-            UpdateState::Updated => UpdateState::Updated,
+            UpdateState::Updated => NetworkState::SettingsChanged,
             UpdateState::NoChange => poll_result,
         }
     }


### PR DESCRIPTION
This PR fixes #368 by refactoring logic in the network stack. This prevents spurious updates of Stabilizer's settings.