### PR TITLE
Updating to HAL mainline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,7 +812,7 @@ dependencies = [
 [[package]]
 name = "stm32h7xx-hal"
 version = "0.9.0"
-source = "git+https://github.com/quartiq/stm32h7xx-hal.git?branch=master#acd47beb4b84b4dc46da3a8b68688bc8c5984604"
+source = "git+https://github.com/quartiq/stm32h7xx-hal.git?rev=acd47be#acd47beb4b84b4dc46da3a8b68688bc8c5984604"
 dependencies = [
  "bare-metal 1.0.0",
  "cast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,7 +812,7 @@ dependencies = [
 [[package]]
 name = "stm32h7xx-hal"
 version = "0.9.0"
-source = "git+https://github.com/quartiq/stm32h7xx-hal.git?rev=b0b8a93#b0b8a930b2c3bc5fcebc2e905b4c5e13360111a5"
+source = "git+https://github.com/quartiq/stm32h7xx-hal.git?branch=master#acd47beb4b84b4dc46da3a8b68688bc8c5984604"
 dependencies = [
  "bare-metal 1.0.0",
  "cast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,10 @@ mcp23017 = "1.0"
 git = "https://github.com/quartiq/rtt-logger.git"
 rev = "70b0eb5"
 
-# fast double buffered DMA without poisoning and buffer swapping
+# The following modifications of the HAL are being used:
+# * fast double buffered DMA without poisoning and buffer swapping
+# * Utilize `master` branch of smoltcp
+# * Utilize `master` branch of HAL
 [dependencies.stm32h7xx-hal]
 features = ["stm32h743v", "rt", "unproven", "ethernet", "quadspi"]
 # version = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ rev = "70b0eb5"
 features = ["stm32h743v", "rt", "unproven", "ethernet", "quadspi"]
 # version = "0.9.0"
 git = "https://github.com/quartiq/stm32h7xx-hal.git"
-rev = "b0b8a93"
+branch = "master"
 
 # link.x section start/end
 [patch.crates-io.cortex-m-rt]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ rev = "70b0eb5"
 features = ["stm32h743v", "rt", "unproven", "ethernet", "quadspi"]
 # version = "0.9.0"
 git = "https://github.com/quartiq/stm32h7xx-hal.git"
-branch = "master"
+rev = "acd47be"
 
 # link.x section start/end
 [patch.crates-io.cortex-m-rt]

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -341,10 +341,13 @@ pub fn setup(
                 polarity: hal::spi::Polarity::IdleHigh,
                 phase: hal::spi::Phase::CaptureOnSecondTransition,
             })
-            .manage_cs()
-            .suspend_when_inactive()
-            .communication_mode(hal::spi::CommunicationMode::Receiver)
-            .cs_delay(design_parameters::ADC_SETUP_TIME);
+            .inter_word_delay(design_parameters::ADC_SETUP_TIME)
+            .hardware_cs(hal::spi::HardwareCS {
+                mode: hal::spi::HardwareCSMode::EndlessTransaction,
+                assertion_delay: design_parameters::ADC_SETUP_TIME,
+                polarity: hal::spi::Polarity::IdleHigh,
+            })
+            .communication_mode(hal::spi::CommunicationMode::Receiver);
 
             let spi: hal::spi::Spi<_, _, u16> = device.SPI2.spi(
                 (spi_sck, spi_miso, hal::spi::NoMosi),
@@ -382,10 +385,13 @@ pub fn setup(
                 polarity: hal::spi::Polarity::IdleHigh,
                 phase: hal::spi::Phase::CaptureOnSecondTransition,
             })
-            .manage_cs()
-            .suspend_when_inactive()
-            .communication_mode(hal::spi::CommunicationMode::Receiver)
-            .cs_delay(design_parameters::ADC_SETUP_TIME);
+            .inter_word_delay(design_parameters::ADC_SETUP_TIME)
+            .hardware_cs(hal::spi::HardwareCS {
+                mode: hal::spi::HardwareCSMode::EndlessTransaction,
+                assertion_delay: design_parameters::ADC_SETUP_TIME,
+                polarity: hal::spi::Polarity::IdleHigh,
+            })
+            .communication_mode(hal::spi::CommunicationMode::Receiver);
 
             let spi: hal::spi::Spi<_, _, u16> = device.SPI3.spi(
                 (spi_sck, spi_miso, hal::spi::NoMosi),
@@ -433,8 +439,11 @@ pub fn setup(
                 polarity: hal::spi::Polarity::IdleHigh,
                 phase: hal::spi::Phase::CaptureOnSecondTransition,
             })
-            .manage_cs()
-            .suspend_when_inactive()
+            .hardware_cs(hal::spi::HardwareCS {
+                mode: hal::spi::HardwareCSMode::EndlessTransaction,
+                assertion_delay: 0.0,
+                polarity: hal::spi::Polarity::IdleHigh,
+            })
             .communication_mode(hal::spi::CommunicationMode::Transmitter)
             .swap_mosi_miso();
 
@@ -465,9 +474,12 @@ pub fn setup(
                 polarity: hal::spi::Polarity::IdleHigh,
                 phase: hal::spi::Phase::CaptureOnSecondTransition,
             })
-            .manage_cs()
+            .hardware_cs(hal::spi::HardwareCS {
+                mode: hal::spi::HardwareCSMode::EndlessTransaction,
+                assertion_delay: 0.0,
+                polarity: hal::spi::Polarity::IdleHigh,
+            })
             .communication_mode(hal::spi::CommunicationMode::Transmitter)
-            .suspend_when_inactive()
             .swap_mosi_miso();
 
             device.SPI5.spi(

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -343,7 +343,7 @@ pub fn setup(
             })
             .inter_word_delay(design_parameters::ADC_SETUP_TIME)
             .hardware_cs(hal::spi::HardwareCS {
-                mode: hal::spi::HardwareCSMode::EndlessTransaction,
+                mode: hal::spi::HardwareCSMode::WordTransaction,
                 assertion_delay: design_parameters::ADC_SETUP_TIME,
                 polarity: hal::spi::Polarity::IdleHigh,
             })
@@ -387,7 +387,7 @@ pub fn setup(
             })
             .inter_word_delay(design_parameters::ADC_SETUP_TIME)
             .hardware_cs(hal::spi::HardwareCS {
-                mode: hal::spi::HardwareCSMode::EndlessTransaction,
+                mode: hal::spi::HardwareCSMode::WordTransaction,
                 assertion_delay: design_parameters::ADC_SETUP_TIME,
                 polarity: hal::spi::Polarity::IdleHigh,
             })
@@ -440,7 +440,7 @@ pub fn setup(
                 phase: hal::spi::Phase::CaptureOnSecondTransition,
             })
             .hardware_cs(hal::spi::HardwareCS {
-                mode: hal::spi::HardwareCSMode::EndlessTransaction,
+                mode: hal::spi::HardwareCSMode::WordTransaction,
                 assertion_delay: 0.0,
                 polarity: hal::spi::Polarity::IdleHigh,
             })
@@ -475,7 +475,7 @@ pub fn setup(
                 phase: hal::spi::Phase::CaptureOnSecondTransition,
             })
             .hardware_cs(hal::spi::HardwareCS {
-                mode: hal::spi::HardwareCSMode::EndlessTransaction,
+                mode: hal::spi::HardwareCSMode::WordTransaction,
                 assertion_delay: 0.0,
                 polarity: hal::spi::Polarity::IdleHigh,
             })

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -341,7 +341,6 @@ pub fn setup(
                 polarity: hal::spi::Polarity::IdleHigh,
                 phase: hal::spi::Phase::CaptureOnSecondTransition,
             })
-            .inter_word_delay(design_parameters::ADC_SETUP_TIME)
             .hardware_cs(hal::spi::HardwareCS {
                 mode: hal::spi::HardwareCSMode::WordTransaction,
                 assertion_delay: design_parameters::ADC_SETUP_TIME,
@@ -385,7 +384,6 @@ pub fn setup(
                 polarity: hal::spi::Polarity::IdleHigh,
                 phase: hal::spi::Phase::CaptureOnSecondTransition,
             })
-            .inter_word_delay(design_parameters::ADC_SETUP_TIME)
             .hardware_cs(hal::spi::HardwareCS {
                 mode: hal::spi::HardwareCSMode::WordTransaction,
                 assertion_delay: design_parameters::ADC_SETUP_TIME,

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -332,7 +332,7 @@ pub fn setup(
                 .pb10
                 .into_alternate_af5()
                 .set_speed(hal::gpio::Speed::VeryHigh);
-            let _spi_nss = gpiob
+            let spi_nss = gpiob
                 .pb9
                 .into_alternate_af5()
                 .set_speed(hal::gpio::Speed::VeryHigh);
@@ -350,7 +350,7 @@ pub fn setup(
             .communication_mode(hal::spi::CommunicationMode::Receiver);
 
             let spi: hal::spi::Spi<_, _, u16> = device.SPI2.spi(
-                (spi_sck, spi_miso, hal::spi::NoMosi),
+                (spi_sck, spi_miso, hal::spi::NoMosi, spi_nss),
                 config,
                 design_parameters::ADC_DAC_SCK_MAX,
                 ccdr.peripheral.SPI2,
@@ -376,7 +376,7 @@ pub fn setup(
                 .pc10
                 .into_alternate_af6()
                 .set_speed(hal::gpio::Speed::VeryHigh);
-            let _spi_nss = gpioa
+            let spi_nss = gpioa
                 .pa15
                 .into_alternate_af6()
                 .set_speed(hal::gpio::Speed::VeryHigh);
@@ -394,7 +394,7 @@ pub fn setup(
             .communication_mode(hal::spi::CommunicationMode::Receiver);
 
             let spi: hal::spi::Spi<_, _, u16> = device.SPI3.spi(
-                (spi_sck, spi_miso, hal::spi::NoMosi),
+                (spi_sck, spi_miso, hal::spi::NoMosi, spi_nss),
                 config,
                 design_parameters::ADC_DAC_SCK_MAX,
                 ccdr.peripheral.SPI3,
@@ -430,7 +430,7 @@ pub fn setup(
                 .pe2
                 .into_alternate_af5()
                 .set_speed(hal::gpio::Speed::VeryHigh);
-            let _spi_nss = gpioe
+            let spi_nss = gpioe
                 .pe4
                 .into_alternate_af5()
                 .set_speed(hal::gpio::Speed::VeryHigh);
@@ -448,7 +448,7 @@ pub fn setup(
             .swap_mosi_miso();
 
             device.SPI4.spi(
-                (spi_sck, spi_miso, hal::spi::NoMosi),
+                (spi_sck, spi_miso, hal::spi::NoMosi, spi_nss),
                 config,
                 design_parameters::ADC_DAC_SCK_MAX,
                 ccdr.peripheral.SPI4,
@@ -465,7 +465,7 @@ pub fn setup(
                 .pf7
                 .into_alternate_af5()
                 .set_speed(hal::gpio::Speed::VeryHigh);
-            let _spi_nss = gpiof
+            let spi_nss = gpiof
                 .pf6
                 .into_alternate_af5()
                 .set_speed(hal::gpio::Speed::VeryHigh);
@@ -483,7 +483,7 @@ pub fn setup(
             .swap_mosi_miso();
 
             device.SPI5.spi(
-                (spi_sck, spi_miso, hal::spi::NoMosi),
+                (spi_sck, spi_miso, hal::spi::NoMosi, spi_nss),
                 config,
                 design_parameters::ADC_DAC_SCK_MAX,
                 ccdr.peripheral.SPI5,


### PR DESCRIPTION
This PR updates to utilize latest version of the HAL (in anticipation of bumping smoltcp). Updates are only around SPI CS control, and I think the new API, while a little distasteful in syntax, is more expressive and useful.

I've tested this on loopback hardware with a 1KHz 1V sinusoid and confirmed things look as expected.