### PR TITLE
use mutex-trait instead of flatten_closures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9a69a963b70ddacfcd382524f72a4576f359af9334b3bf48a79566590bb8bfa"
 dependencies = [
  "bitrate",
- "cortex-m 0.6.7",
+ "cortex-m 0.7.2",
  "embedded-hal",
 ]
 
@@ -433,6 +433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mutex-trait"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4bb1638d419e12f8b1c43d9e639abd0d1424285bdea2f76aa231e233c63cd3a"
+
+[[package]]
 name = "nanorand"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +784,7 @@ dependencies = [
  "mcp23017",
  "miniconf",
  "minimq",
+ "mutex-trait",
  "nb 1.0.0",
  "num_enum",
  "paste",
@@ -803,7 +810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b672c837e0ee8158ecc7fce0f9a948dd0693a9c588338e728d14b73307a0b7d"
 dependencies = [
  "bare-metal 0.2.5",
- "cortex-m 0.6.7",
+ "cortex-m 0.7.2",
  "cortex-m-rt",
  "vcell",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ miniconf = "0.1.0"
 shared-bus = {version = "0.2.2", features = ["cortex-m"] }
 serde-json-core = "0.4"
 mcp23017 = "1.0"
+mutex-trait = "0.2"
 
 # rtt-target bump
 [dependencies.rtt-logger]

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -4,9 +4,10 @@
 
 use core::sync::atomic::{fence, Ordering};
 
+use mutex_trait::prelude::*;
+
 use dsp::iir;
 use stabilizer::{
-    flatten_closures,
     hardware::{
         self,
         adc::{Adc0Input, Adc1Input, AdcCode},
@@ -164,7 +165,7 @@ const APP: () = {
         let hold =
             settings.force_hold || (digital_inputs[1] && settings.allow_hold);
 
-        flatten_closures!(with_buffer, adc0, adc1, dac0, dac1, {
+        (adc0, adc1, dac0, dac1).lock(|adc0, adc1, dac0, dac1| {
             let adc_samples = [adc0, adc1];
             let dac_samples = [dac0, dac1];
 

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -4,9 +4,10 @@
 
 use core::sync::atomic::{fence, Ordering};
 
+use mutex_trait::prelude::*;
+
 use dsp::{Accu, Complex, ComplexExt, Lockin, RPLL};
 use stabilizer::{
-    flatten_closures,
     hardware::{
         self,
         adc::{Adc0Input, Adc1Input, AdcCode},
@@ -223,7 +224,7 @@ const APP: () = {
             reference_phase.wrapping_mul(settings.lockin_harmonic),
         );
 
-        flatten_closures!(with_buffer, adc0, adc1, dac0, dac1, {
+        (adc0, adc1, dac0, dac1).lock(|adc0, adc1, dac0, dac1| {
             let adc_samples = [adc0, adc1];
             let mut dac_samples = [dac0, dac1];
 

--- a/src/hardware/dac.rs
+++ b/src/hardware/dac.rs
@@ -52,6 +52,8 @@
 ///! served promptly after the transfer completes.
 use stm32h7xx_hal as hal;
 
+use mutex_trait::Mutex;
+
 use super::design_parameters::{SampleBuffer, SAMPLE_BUFFER_SIZE};
 use super::timers;
 
@@ -217,6 +219,15 @@ macro_rules! dac_output {
                 unsafe {
                     self.transfer.next_dbm_transfer_with(|buf, _current| f(buf))
                 }
+            }
+        }
+
+        // This is not actually a Mutex. It only re-uses the semantics and macros of mutex-trait
+        // to reduce rightward drift when jointly calling `with_buffer(f)` on multiple DAC/ADCs.
+        impl Mutex for $name {
+            type Data = SampleBuffer;
+            fn lock<R>(&mut self, f: impl FnOnce(&mut Self::Data) -> R) -> R {
+                self.with_buffer(f).unwrap()
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,16 +3,3 @@
 
 pub mod hardware;
 pub mod net;
-
-/// Macro to reduce rightward drift when calling the same closure-based API
-/// on multiple structs simultaneously, e.g. when accessing DMA buffers.
-/// This could be improved a bit using the tuple-based style from `mutex-trait`.
-#[macro_export]
-macro_rules! flatten_closures {
-    ($fn:ident, $e:ident, $fun:block) => {
-        $e.$fn(|$e| $fun ).unwrap()
-    };
-    ($fn:ident, $e:ident, $($es:ident),+, $fun:block) => {
-        $e.$fn(|$e| flatten_closures!($fn, $($es),*, $fun)).unwrap()
-    };
-}


### PR DESCRIPTION
To have less code to maintain and clean up the API a bit.

* [x] tested on multiple applications (dual-iir, fls)