### PR TITLE
Accelerating doc CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,6 @@ jobs:
           bundle config path vendor/bundle
           bundle install
 
-          rake build
+          bundle exec rake build
           mv ../target/thumbv7em-none-eabihf/doc _site/stabilizer/firmware
-          rake test
+          bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,24 +126,9 @@ jobs:
           # auto-generated code.
           args: --dir target/thumbv7em-none-eabihf/doc --ignore-fragments --check-http --check-intra-doc-links
 
-      - uses: lemonarc/jekyll-action@1.0.0
-        working-directory: docs
-
-      - name: Setup Site
+      - name: Test Site
         working-directory: docs
         run: |
-          mkdir _site/stabilizer
-          mv _site/* _site/stabilizer
+          rake build
           mv ../target/thumbv7em-none-eabihf/doc _site/stabilizer/firmware
-
-      - name: Test User Manual
-        uses: chabad360/htmlproofer@v1.1
-        working-directory: docs
-        with:
-          directory: "./_site/stabilizer"
-          arguments:
-            --assume-extension
-            --file-ignore "/stabilizer\/firmware\/.*/"
-            --url-irgnore "/quartiq.de\/stabilizer/"
-            --allow-hash-href
-            --typhoeus_config '{"ssl_verify_peer": false}'
+          rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,9 @@ jobs:
             --root cargo-cache
             cargo-deadlinks
 
+      - name: Update Path
+        run: echo "./cargo-cache" >> $GITHUB_PATH
+
       - name: cargo doc
         uses: actions-rs/cargo@v1
         with:
@@ -129,8 +132,6 @@ jobs:
 
       - name: cargo deadlinks
         uses: actions-rs/cargo@v1
-        env:
-          PATH: cargo-cache;${{env.PATH}}
         with:
           command: deadlinks
           # We intentionally ignore fragments, as RTIC may generate fragments for various

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
           args: --package dsp --target=x86_64-unknown-linux-gnu
 
   doc:
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -93,6 +94,12 @@ jobs:
         with:
           ruby-version: 2.7.x
 
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: thumbv7em-none-eabihf
+          override: true
+
       - uses: actions/cache@v2
         with:
           path: docs/vendor/bundle
@@ -100,29 +107,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-
 
-      - uses: actions/cache@v2
-        with:
-          path: cargo-cache
-          key: ${{runner.os}}-cargo-${{ hashFiles('cargo-cache/bins/*') }}
-          restore-keys: |
-            ${{runner.os}}-cargo-
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: thumbv7em-none-eabihf
-          override: true
+      - uses: Swatinem/rust-cache@v1
 
       - name: Install Deadlinks
         uses: actions-rs/cargo@v1
         with:
           command: install
           args: |
-            --root cargo-cache
             cargo-deadlinks
-
-      - name: Update Path
-        run: echo "./cargo-cache" >> $GITHUB_PATH
 
       - name: cargo doc
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: docs/vendor/bundle
-          keys: ${{runner.os}}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{runner.os}}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-gems-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,6 @@ jobs:
           args: --package dsp --target=x86_64-unknown-linux-gnu
 
   doc:
-
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,19 +93,19 @@ jobs:
         with:
           ruby-version: 2.7.x
 
-      - name: Setup Jekyll
-        working-directory: docs
-        run: |
-          gem update
-          gem update bundler
-          gem install jekyll bundler
-          bundler install
+      - uses: actions/cache@v2
+        with:
+          path: docs/vendor/bundle
+          keys: ${{runner.os}}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
 
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: thumbv7em-none-eabihf
           override: true
+
       - name: Install Deadlinks
         uses: actions-rs/cargo@v1
         with:
@@ -126,14 +126,24 @@ jobs:
           # auto-generated code.
           args: --dir target/thumbv7em-none-eabihf/doc --ignore-fragments --check-http --check-intra-doc-links
 
-      - name: Move firmware documents
-        run: |
-          mkdir -p docs/_site/stabilizer
+      - uses: lemonarc/jekyll-action@1.0.0
+        working-directory: docs
 
-      - name: Test User Manual
+      - name: Setup Site
         working-directory: docs
         run: |
-          rake build
+          mkdir _site/stabilizer
+          mv _site/* _site/stabilizer
           mv ../target/thumbv7em-none-eabihf/doc _site/stabilizer/firmware
-          rake test
 
+      - name: Test User Manual
+        uses: chabad360/htmlproofer@v1.1
+        working-directory: docs
+        with:
+          directory: "./_site/stabilizer"
+          arguments:
+            --assume-extension
+            --file-ignore "/stabilizer\/firmware\/.*/"
+            --url-irgnore "/quartiq.de\/stabilizer/"
+            --allow-hash-href
+            --typhoeus_config '{"ssl_verify_peer": false}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-
 
+      - uses: actions/cache@v2
+        with:
+          path: cargo-cache
+          key: ${{runner.os}}-cargo
+          restore-keys: |
+            ${{runner.os}}-cargo
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -110,7 +117,9 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: cargo-deadlinks
+          args: |
+            --root cargo-cache
+            cargo-deadlinks
 
       - name: cargo doc
         uses: actions-rs/cargo@v1
@@ -120,6 +129,8 @@ jobs:
 
       - name: cargo deadlinks
         uses: actions-rs/cargo@v1
+        env:
+          PATH: cargo-cache;${{env.PATH}}
         with:
           command: deadlinks
           # We intentionally ignore fragments, as RTIC may generate fragments for various
@@ -129,6 +140,10 @@ jobs:
       - name: Test Site
         working-directory: docs
         run: |
+          # Install depedencies at our cache location
+          bundle config path vendor/bundle
+          bundle install
+
           rake build
           mv ../target/thumbv7em-none-eabihf/doc _site/stabilizer/firmware
           rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,9 +103,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: cargo-cache
-          key: ${{runner.os}}-cargo
+          key: ${{runner.os}}-cargo-${{ hashFiles('cargo-cache/bins/*') }}
           restore-keys: |
-            ${{runner.os}}-cargo
+            ${{runner.os}}-cargo-
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -3,7 +3,7 @@
 /// MQTT broker IPv4 address
 ///
 /// In the default configuration, the IP address is defined as 10.34.16.10.
-pub const MQTT_BROKER: [u8; 4] = [10, 35, 16, 10];
+pub const MQTT_BROKER: [u8; 4] = [10, 34, 16, 10];
 
 /// Sampling Frequency
 ///

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -3,7 +3,7 @@
 /// MQTT broker IPv4 address
 ///
 /// In the default configuration, the IP address is defined as 10.34.16.10.
-pub const MQTT_BROKER: [u8; 4] = [10, 34, 16, 10];
+pub const MQTT_BROKER: [u8; 4] = [10, 35, 16, 10];
 
 /// Sampling Frequency
 ///


### PR DESCRIPTION
This PR fixes #403 by utilize github actions caches to accelerate the doc test CI check. `cargo-deadlinks` is cached, ruby gems are cached, and Rust dependency installations are cached.

Questions:
Should the Rust cache be tagged on a specific key so that we don't pollute the cache with each PR?