### PR TITLE
Correcting Stabilizer user manual release workflow

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: peaceiris/actions-gh-pages@v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs
+          publish_dir: book/stabilizer-manual
           enable_jekyll: true
           publish_branch: pages
           force_orphan: true

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: peaceiris/actions-gh-pages@v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: book/stabilizer-manual
+          publish_dir: book/stabilizer-manual/html
           enable_jekyll: true
           publish_branch: pages
           force_orphan: true

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build Book
         working-directory: book
-        run:
+        run: |
           mv ../target/thumbv7em-none-eabihf/doc src/firmware
           mdbook build
 

--- a/book/book.toml
+++ b/book/book.toml
@@ -10,7 +10,7 @@ create-missing = false
 build-dir = "stabilizer-manual"
 
 [output.html]
-site-url = "https://quartiq.de/stabilizer"
+site-url = "/stabilizer"
 git-repository-url = "https://github.com/quartiq/stabilizer"
 
 [output.linkcheck]


### PR DESCRIPTION
This fixes a few issues with the workflow to release the Stabilizer user manual.

Workflow manually run and verified at https://github.com/quartiq/stabilizer/actions/runs/1113289654