### PR TITLE
Adding optimized signal generator

### DIFF
--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -279,7 +279,7 @@ const APP: () = {
 
         let signal_config = {
             let frequency_tuning_word =
-                (1u64 << (32 - BATCH_SIZE_SIZE_LOG2)) as u32;
+                (1u64 << (32 - BATCH_SIZE_SIZE_LOG2)) as i32;
 
             signal_generator::Config {
                 // Same frequency as batch size.

--- a/src/hardware/signal_generator.rs
+++ b/src/hardware/signal_generator.rs
@@ -183,13 +183,13 @@ impl core::iter::Iterator for SignalGenerator {
             Signal::Cosine => (dsp::cossin(self.phase_accumulator).0 >> 16),
             Signal::Square => {
                 if sign {
-                    -i16::MAX as i32
+                    -1 << 15
                 } else {
-                    i16::MAX as i32
+                    1 << 15
                 }
             }
             Signal::Triangle => {
-                i16::MAX as i32 - (self.phase_accumulator.abs() >> 15)
+                (self.phase_accumulator >> 15).abs() - (1 << 15)
             }
         };
 


### PR DESCRIPTION
This PR fixes #415 by implementing the proposed changes to reduce processing overhead.

Unfortunately, even with these changes, it appears to not be possible to stream at full data rate even when using square waves - there are still losses of ~0.5% of frames.

These changes were run with a signal frequency/amplitude/symmetry sweep from 500Hz-1KHz, Symmetry 0-1, and amplitude 1V -> 2V and output waveform on a scope looked well-formed.