### PR TITLE
Updating miniconf/minimq to utilize pings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,8 +203,7 @@ dependencies = [
 [[package]]
 name = "derive_miniconf"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1622cf1dddfe55eaa54a5223dae7de264d40110080bc55c6d8a9d89daf882d05"
+source = "git+https://github.com/quartiq/miniconf?rev=1ac3870#1ac3870a63bd4246438ea67a683ec0f85b296a98"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -426,8 +425,7 @@ dependencies = [
 [[package]]
 name = "miniconf"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb9f957ca15c9f2fc59d2ee1016029822ed1bddd622bcbaefac9c8b2499bb4a"
+source = "git+https://github.com/quartiq/miniconf?rev=1ac3870#1ac3870a63bd4246438ea67a683ec0f85b296a98"
 dependencies = [
  "derive_miniconf",
  "heapless 0.7.3",
@@ -440,11 +438,11 @@ dependencies = [
 [[package]]
 name = "minimq"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff318a5cbde4315f61fb86145ed2c00a49dc613a71aff920130b47d0a12490f"
+source = "git+https://github.com/quartiq/minimq?rev=73424f2#73424f22d6737e45589cb5aa63b918c3e28642e0"
 dependencies = [
  "bit_field",
  "embedded-nal",
+ "embedded-time",
  "enum-iterator",
  "heapless 0.7.3",
  "smlang",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,14 @@ rev = "33aa67d"
 git = "https://github.com/rust-embedded/cortex-m-rt.git"
 rev = "a2e3ad5"
 
+[patch.crates-io.minimq]
+git = "https://github.com/quartiq/minimq"
+rev = "73424f2"
+
+[patch.crates-io.miniconf]
+git = "https://github.com/quartiq/miniconf"
+rev = "1ac3870"
+
 [patch.crates-io.heapless]
 git = "https://github.com/quartiq/heapless.git"
 branch = "feature/assume-init"

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -14,7 +14,7 @@ pub mod network_processor;
 pub mod shared;
 pub mod telemetry;
 
-use crate::hardware::{EthernetPhy, NetworkStack};
+use crate::hardware::{system_timer::SystemTimer, EthernetPhy, NetworkStack};
 use data_stream::{DataStream, FrameGenerator};
 use minimq::embedded_nal::IpAddr;
 use network_processor::NetworkProcessor;
@@ -46,7 +46,7 @@ pub enum NetworkState {
 }
 /// A structure of Stabilizer's default network users.
 pub struct NetworkUsers<S: Default + Miniconf, T: Serialize> {
-    pub miniconf: miniconf::MqttClient<S, NetworkReference>,
+    pub miniconf: miniconf::MqttClient<S, NetworkReference, SystemTimer>,
     pub processor: NetworkProcessor,
     stream: DataStream,
     generator: Option<FrameGenerator>,
@@ -90,6 +90,7 @@ where
             &get_client_id(app, "settings", mac),
             &prefix,
             broker,
+            SystemTimer::default(),
         )
         .unwrap();
 

--- a/src/net/telemetry.rs
+++ b/src/net/telemetry.rs
@@ -15,12 +15,14 @@ use minimq::QoS;
 use serde::Serialize;
 
 use super::NetworkReference;
-use crate::hardware::{adc::AdcCode, afe::Gain, dac::DacCode};
+use crate::hardware::{
+    adc::AdcCode, afe::Gain, dac::DacCode, system_timer::SystemTimer,
+};
 use minimq::embedded_nal::IpAddr;
 
 /// The telemetry client for reporting telemetry data over MQTT.
 pub struct TelemetryClient<T: Serialize> {
-    mqtt: minimq::Minimq<NetworkReference, 256>,
+    mqtt: minimq::Minimq<NetworkReference, SystemTimer, 256>,
     telemetry_topic: String<128>,
     _telemetry: core::marker::PhantomData<T>,
 }
@@ -106,7 +108,13 @@ impl<T: Serialize> TelemetryClient<T> {
         prefix: &str,
         broker: IpAddr,
     ) -> Self {
-        let mqtt = minimq::Minimq::new(broker, client_id, stack).unwrap();
+        let mqtt = minimq::Minimq::new(
+            broker,
+            client_id,
+            stack,
+            SystemTimer::default(),
+        )
+        .unwrap();
 
         let mut telemetry_topic: String<128> = String::from(prefix);
         telemetry_topic.push_str("/telemetry").unwrap();


### PR DESCRIPTION
This PR updates `stabilizer` to utilize miniconf/minimq versions that implement MQTT ping request/responses periodically. 

This fixes #433

TODO:
- [ ] Update revisions once PRs are merged
- [ ] Merge https://github.com/quartiq/minimq/pull/55
- [ ] Merge https://github.com/quartiq/miniconf/pull/50