### PR TITLE
DAC initialization update to fix random pulses on power cycle

### DIFF
--- a/src/hardware/dac.rs
+++ b/src/hardware/dac.rs
@@ -211,13 +211,13 @@ macro_rules! dac_output {
                 let mut spi = spi.disable();
                 spi.listen(hal::spi::Event::Error);
 
-                // AXISRAM is uninitialized. As such, we manually zero-initialize it here before
-                // starting the transfer.
+                // AXISRAM is uninitialized. As such, we manually initialize it for a 0V DAC output
+                // here before starting the transfer .
                 // Note(unsafe): We currently own all DAC_BUF[index] buffers and are not using them
                 // elsewhere, so it is safe to access them here.
                 for buf in unsafe { DAC_BUF[$index].iter_mut() } {
                     for byte in buf.iter_mut() {
-                        *byte = 0x8000;  // mid-scale, 0V
+                        *byte = DacCode::try_from(0.0f32).unwrap().0;
                     }
                 }
 

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -556,9 +556,9 @@ pub fn setup(
         let _dac0_ldac_n =
             gpioe.pe11.into_push_pull_output().set_low().unwrap();
         let _dac1_ldac_n =
-            gpioe.pe15.into_push_pull_output().set_low().unwrap(); 
+            gpioe.pe15.into_push_pull_output().set_low().unwrap();
         dac_clr_n.set_high().unwrap();
-        
+
         (dac0, dac1)
     };
 


### PR DESCRIPTION
Issue #447 reports random pulses on the DAC outputs after a soft or hard reset.
This can be fixed by using different initial DAC output buffer values on stabilizer and cycling the !CLR pin of the DAC.

Note: this software patch also needs some hardware modifications to work (adding pullups on DAC !LDAC pins, see #447)