### PR TITLE
pounder: warn only if fifo more than half full

### DIFF
--- a/src/hardware/pounder/dds_output.rs
+++ b/src/hardware/pounder/dds_output.rs
@@ -33,8 +33,8 @@
 ///! # Limitations
 ///!
 ///! The QSPI output FIFO is used as an intermediate buffer for holding pending QSPI writes. Because
-///! of this, the implementation only supports up to 16 serialized bytes (the QSPI FIFO is 4 32-bit
-///! words wide) in a single update.
+///! of this, the implementation only supports up to 16 serialized bytes (the QSPI FIFO is 8 32-bit
+///! words, or 32 bytes, wide) in a single update.
 ///!
 ///! There is currently no synchronization between completion of the QSPI data write and the
 ///! IO-update signal. It is currently assumed that the QSPI transfer will always complete within a
@@ -103,8 +103,9 @@ impl DdsOutput {
     /// Write a profile to the stream.
     ///
     /// # Note:
-    /// If a profile of more than 4 words is provided, it is possible that the QSPI interface will
-    /// stall execution.
+    /// If a profile of more than 8 words is provided, the QSPI interface will likely
+    /// stall execution. If there are still bytes pending in the FIFO, the write will certainly
+    /// stall.
     ///
     /// # Args
     /// * `profile` - The serialized DDS profile to write.

--- a/src/hardware/pounder/dds_output.rs
+++ b/src/hardware/pounder/dds_output.rs
@@ -113,7 +113,8 @@ impl DdsOutput {
         // fashion.
         let regs = unsafe { &*hal::stm32::QUADSPI::ptr() };
 
-        if regs.sr.read().flevel() != 0 {
+        // Warn if the fifo is still at least half full.
+        if regs.sr.read().flevel().bits() >= 16 {
             warn!("QSPI stalling")
         }
 


### PR DESCRIPTION
In regular operation when the process task frequently queues large ~14 byte write,
and if there is a miniconf update, the second will see a non-empty fifo.
It only becomes problematic if this would lead to
significant stalls. As long as updates are smaller than half the fifo
level, this is benign.
