### PR TITLE
Indicating stabilizer status via MQTT will

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,8 +224,7 @@ dependencies = [
 [[package]]
 name = "derive_miniconf"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a09410a9472600744ed45ab245fc56bce9c44a422434cf91cad613ac5857f93c"
+source = "git+https://github.com/quartiq/miniconf?rev=f239869#f239869493620c23e496041d36e58c1fde3517c4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -422,8 +421,7 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 [[package]]
 name = "miniconf"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1052ead57d31cf73a64ed51f8c8be77ed266fae44b62addbf84f086d30e725f7"
+source = "git+https://github.com/quartiq/miniconf?rev=f239869#f239869493620c23e496041d36e58c1fde3517c4"
 dependencies = [
  "derive_miniconf",
  "heapless",
@@ -435,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "minimq"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2663108c61423acb77305e78252a745b7c56a7d781789997009c83364b1cb652"
+checksum = "ea5e759f258bee54765698d7fc1219692b1bce77f72a77e360fe1d73fcbdeca4"
 dependencies = [
  "bit_field",
  "embedded-nal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ shared-bus = {version = "0.2.2", features = ["cortex-m"] }
 serde-json-core = "0.4"
 mcp23017 = "1.0"
 mutex-trait = "0.2"
-minimq = "0.4"
+minimq = "0.5.1"
 
 # rtt-target bump
 [dependencies.rtt-logger]
@@ -64,6 +64,10 @@ features = ["stm32h743v", "rt", "unproven", "ethernet", "quadspi"]
 # version = "0.9.0"
 git = "https://github.com/quartiq/stm32h7xx-hal.git"
 rev = "33aa67d"
+
+[patch.crates-io.miniconf]
+git = "https://github.com/quartiq/miniconf"
+rev = "f239869"
 
 # link.x section start/end
 [patch.crates-io.cortex-m-rt]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ rev = "33aa67d"
 
 [patch.crates-io.miniconf]
 git = "https://github.com/quartiq/miniconf"
-rev = "f239869"
+rev = "eca1bf7"
 
 # link.x section start/end
 [patch.crates-io.cortex-m-rt]

--- a/src/net/telemetry.rs
+++ b/src/net/telemetry.rs
@@ -139,7 +139,13 @@ impl<T: Serialize> TelemetryClient<T> {
             serde_json_core::to_vec(telemetry).unwrap();
         self.mqtt
             .client
-            .publish(&self.telemetry_topic, &telemetry, QoS::AtMostOnce, Retain::NotRetained, &[])
+            .publish(
+                &self.telemetry_topic,
+                &telemetry,
+                QoS::AtMostOnce,
+                Retain::NotRetained,
+                &[],
+            )
             .ok();
     }
 

--- a/src/net/telemetry.rs
+++ b/src/net/telemetry.rs
@@ -11,7 +11,7 @@
 ///! required immediately before transmission. This ensures that any slower computation required
 ///! for unit conversion can be off-loaded to lower priority tasks.
 use heapless::{String, Vec};
-use minimq::QoS;
+use minimq::{QoS, Retain};
 use serde::Serialize;
 
 use super::NetworkReference;
@@ -139,7 +139,7 @@ impl<T: Serialize> TelemetryClient<T> {
             serde_json_core::to_vec(telemetry).unwrap();
         self.mqtt
             .client
-            .publish(&self.telemetry_topic, &telemetry, QoS::AtMostOnce, &[])
+            .publish(&self.telemetry_topic, &telemetry, QoS::AtMostOnce, Retain::NotRetained, &[])
             .ok();
     }
 


### PR DESCRIPTION
This PR fixes #302 by utilizing a miniconf version that uses the <prefix>/alive topic to indicate life status of stabilizer.

This branch was run locally and ethernet was pulled. It was observed that after 2 and a half minutes, the `<prefix>/alive` topic was published as 0.

We may want to reduce the keep-alive interval, as it appears the will is only published after 2.5x the keepalive interval has elapsed.