### PR TITLE
Adding settings republish support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,8 +436,9 @@ dependencies = [
 
 [[package]]
 name = "minimq"
-version = "0.5.1"
-source = "git+https://github.com/quartiq/minimq?rev=47fbf9d#47fbf9d8ed0eb6511d4965a016fb4c2b0c07f624"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf42a70baa4f1f568529bd8b9ae388cac43cd31a506197e6c26e9cf647aa9014"
 dependencies = [
  "bit_field",
  "embedded-nal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,8 +223,9 @@ dependencies = [
 
 [[package]]
 name = "derive_miniconf"
-version = "0.1.1"
-source = "git+https://github.com/quartiq/miniconf?rev=f156cdd#f156cddd9c026abcda1d11471ff63ca175d7d5c8"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf0746ffedecccb7abefca46c550a49c50ee40fa5fd2555cfa115a1a109324a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -348,7 +349,7 @@ dependencies = [
 [[package]]
 name = "idsp"
 version = "0.3.0"
-source = "git+https://github.com/quartiq/idsp?branch=feature/serialize#f7e60d613bc7f6d13e7b76a724c7c7b3113150f3"
+source = "git+https://github.com/quartiq/idsp?rev=799e6b6#799e6b64790c185fd4e19f193c1f8d10b95fbbff"
 dependencies = [
  "miniconf",
  "num-complex 0.4.0",
@@ -419,8 +420,9 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "miniconf"
-version = "0.2.0"
-source = "git+https://github.com/quartiq/miniconf?rev=f156cdd#f156cddd9c026abcda1d11471ff63ca175d7d5c8"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bebe771bb9b1d6ab2735374465002f6e15db45c8d863b8b1873881e98d6da22"
 dependencies = [
  "derive_miniconf",
  "heapless",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ dependencies = [
 [[package]]
 name = "derive_miniconf"
 version = "0.1.1"
-source = "git+https://github.com/quartiq/miniconf?rev=eca1bf7#eca1bf7d1dac366376f5c3f8079527ef692ad982"
+source = "git+https://github.com/quartiq/miniconf?rev=f156cdd#f156cddd9c026abcda1d11471ff63ca175d7d5c8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -348,8 +348,7 @@ dependencies = [
 [[package]]
 name = "idsp"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba7f8f7fa2294113c0ec55a9542465736b6906c5d12dd3d5c70a1eca89b0f11"
+source = "git+https://github.com/quartiq/idsp?branch=feature/serialize#f7e60d613bc7f6d13e7b76a724c7c7b3113150f3"
 dependencies = [
  "miniconf",
  "num-complex 0.4.0",
@@ -421,7 +420,7 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 [[package]]
 name = "miniconf"
 version = "0.2.0"
-source = "git+https://github.com/quartiq/miniconf?rev=eca1bf7#eca1bf7d1dac366376f5c3f8079527ef692ad982"
+source = "git+https://github.com/quartiq/miniconf?rev=f156cdd#f156cddd9c026abcda1d11471ff63ca175d7d5c8"
 dependencies = [
  "derive_miniconf",
  "heapless",
@@ -429,13 +428,13 @@ dependencies = [
  "minimq",
  "serde",
  "serde-json-core",
+ "smlang",
 ]
 
 [[package]]
 name = "minimq"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5e759f258bee54765698d7fc1219692b1bce77f72a77e360fe1d73fcbdeca4"
+source = "git+https://github.com/quartiq/minimq?rev=47fbf9d#47fbf9d8ed0eb6511d4965a016fb4c2b0c07f624"
 dependencies = [
  "bit_field",
  "embedded-nal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,8 +348,9 @@ dependencies = [
 
 [[package]]
 name = "idsp"
-version = "0.3.0"
-source = "git+https://github.com/quartiq/idsp?rev=799e6b6#799e6b64790c185fd4e19f193c1f8d10b95fbbff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73292b6fa42085c110a8e4d4a1de6c9e8f0123da52457c16c83b293355b72160"
 dependencies = [
  "miniconf",
  "num-complex 0.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ rev = "33aa67d"
 
 [patch.crates-io.idsp]
 git = "https://github.com/quartiq/idsp"
-branch = "feature/serialize"
+rev = "799e6b6"
 
 # link.x section start/end
 [patch.crates-io.cortex-m-rt]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ shared-bus = {version = "0.2.2", features = ["cortex-m"] }
 serde-json-core = "0.4"
 mcp23017 = "1.0"
 mutex-trait = "0.2"
-minimq = "0.5.1"
+minimq = "0.5.2"
 
 # rtt-target bump
 [dependencies.rtt-logger]
@@ -77,10 +77,6 @@ branch = "feature/assume-init"
 [dependencies.smoltcp-nal]
 git = "https://github.com/quartiq/smoltcp-nal.git"
 rev = "a28e41f"
-
-[patch.crates-io.minimq]
-git = "https://github.com/quartiq/minimq"
-rev = "47fbf9d"
 
 [features]
 nightly = ["cortex-m/inline-asm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ num_enum = { version = "0.5.4", default-features = false }
 paste = "1"
 idsp = "0.3.0"
 ad9959 = { path = "ad9959" }
-miniconf = "0.2.0"
+miniconf = "0.3"
 shared-bus = {version = "0.2.2", features = ["cortex-m"] }
 serde-json-core = "0.4"
 mcp23017 = "1.0"
@@ -65,9 +65,9 @@ features = ["stm32h743v", "rt", "unproven", "ethernet", "quadspi"]
 git = "https://github.com/quartiq/stm32h7xx-hal.git"
 rev = "33aa67d"
 
-[patch.crates-io.miniconf]
-git = "https://github.com/quartiq/miniconf"
-rev = "eca1bf7"
+[patch.crates-io.idsp]
+git = "https://github.com/quartiq/idsp"
+branch = "feature/serialize"
 
 # link.x section start/end
 [patch.crates-io.cortex-m-rt]
@@ -81,6 +81,10 @@ branch = "feature/assume-init"
 [dependencies.smoltcp-nal]
 git = "https://github.com/quartiq/smoltcp-nal.git"
 rev = "a28e41f"
+
+[patch.crates-io.minimq]
+git = "https://github.com/quartiq/minimq"
+rev = "47fbf9d"
 
 [features]
 nightly = ["cortex-m/inline-asm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ nb = "1.0.0"
 asm-delay = "0.9.0"
 num_enum = { version = "0.5.4", default-features = false }
 paste = "1"
-idsp = "0.3.0"
+idsp = "0.4.0"
 ad9959 = { path = "ad9959" }
 miniconf = "0.3"
 shared-bus = {version = "0.2.2", features = ["cortex-m"] }
@@ -64,10 +64,6 @@ features = ["stm32h743v", "rt", "unproven", "ethernet", "quadspi"]
 # version = "0.9.0"
 git = "https://github.com/quartiq/stm32h7xx-hal.git"
 rev = "33aa67d"
-
-[patch.crates-io.idsp]
-git = "https://github.com/quartiq/idsp"
-rev = "799e6b6"
 
 # link.x section start/end
 [patch.crates-io.cortex-m-rt]

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -50,7 +50,6 @@ use stabilizer::{
     net::{
         data_stream::{FrameGenerator, StreamFormat, StreamTarget},
         miniconf::Miniconf,
-        serde::Deserialize,
         telemetry::{Telemetry, TelemetryBuffer},
         NetworkState, NetworkUsers,
     },
@@ -68,7 +67,7 @@ const BATCH_SIZE: usize = 8;
 // 128, there is 1.28uS per sample, corresponding to a sampling frequency of 781.25 KHz.
 const SAMPLE_TICKS_LOG2: u8 = 7;
 
-#[derive(Clone, Copy, Debug, Deserialize, Miniconf)]
+#[derive(Clone, Copy, Debug, Miniconf)]
 pub struct Settings {
     /// Configure the Analog Front End (AFE) gain.
     ///

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -53,7 +53,7 @@ use stabilizer::{
     net::{
         data_stream::{FrameGenerator, StreamFormat, StreamTarget},
         miniconf::Miniconf,
-        serde::Deserialize,
+        serde::{Deserialize, Serialize},
         telemetry::{Telemetry, TelemetryBuffer},
         NetworkState, NetworkUsers,
     },
@@ -68,7 +68,7 @@ const BATCH_SIZE_SIZE_LOG2: u8 = 3;
 // period of 1.28 uS or 781.25 KHz.
 const ADC_SAMPLE_TICKS_LOG2: u8 = 7;
 
-#[derive(Copy, Clone, Debug, Deserialize, Miniconf)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, Miniconf)]
 enum Conf {
     /// Output the lockin magnitude.
     Magnitude,
@@ -86,7 +86,7 @@ enum Conf {
     Modulation,
 }
 
-#[derive(Copy, Clone, Debug, Miniconf, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Miniconf, Serialize, Deserialize, PartialEq)]
 enum LockinMode {
     /// Utilize an internally generated reference for demodulation
     Internal,
@@ -94,7 +94,7 @@ enum LockinMode {
     External,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Miniconf)]
+#[derive(Copy, Clone, Debug, Miniconf)]
 pub struct Settings {
     /// Configure the Analog Front End (AFE) gain.
     ///

--- a/src/hardware/signal_generator.rs
+++ b/src/hardware/signal_generator.rs
@@ -3,10 +3,10 @@ use crate::{
 };
 use core::convert::TryFrom;
 use miniconf::Miniconf;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Types of signals that can be generated.
-#[derive(Copy, Clone, Debug, Deserialize, Miniconf)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, Miniconf)]
 pub enum Signal {
     Cosine,
     Square,

--- a/src/net/data_stream.rs
+++ b/src/net/data_stream.rs
@@ -63,7 +63,9 @@ static mut FRAME_DATA: [u8; FRAME_SIZE * FRAME_COUNT] =
 ///
 /// ## Example
 /// `{"ip": [192, 168,0, 1], "port": 1111}`
-#[derive(Copy, Clone, Debug, MiniconfAtomic, Serialize, Deserialize, Default)]
+#[derive(
+    Copy, Clone, Debug, MiniconfAtomic, Serialize, Deserialize, Default,
+)]
 pub struct StreamTarget {
     pub ip: [u8; 4],
     pub port: u16,

--- a/src/net/data_stream.rs
+++ b/src/net/data_stream.rs
@@ -25,7 +25,7 @@
 use heapless::spsc::{Consumer, Producer, Queue};
 use miniconf::MiniconfAtomic;
 use num_enum::IntoPrimitive;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use smoltcp_nal::embedded_nal::{IpAddr, Ipv4Addr, SocketAddr, UdpClientStack};
 
 use heapless::pool::{Box, Init, Pool, Uninit};
@@ -63,7 +63,7 @@ static mut FRAME_DATA: [u8; FRAME_SIZE * FRAME_COUNT] =
 ///
 /// ## Example
 /// `{"ip": [192, 168,0, 1], "port": 1111}`
-#[derive(Copy, Clone, Debug, MiniconfAtomic, Deserialize, Default)]
+#[derive(Copy, Clone, Debug, MiniconfAtomic, Serialize, Deserialize, Default)]
 pub struct StreamTarget {
     pub ip: [u8; 4],
     pub port: u16,

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -47,7 +47,7 @@ pub enum NetworkState {
 /// A structure of Stabilizer's default network users.
 pub struct NetworkUsers<S: Default + Miniconf, T: Serialize> {
     pub miniconf:
-        miniconf::MqttClient<S, NetworkReference, SystemTimer, 512, 1>,
+        miniconf::MqttClient<S, NetworkReference, SystemTimer, 512>,
     pub processor: NetworkProcessor,
     stream: DataStream,
     generator: Option<FrameGenerator>,

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -46,8 +46,7 @@ pub enum NetworkState {
 }
 /// A structure of Stabilizer's default network users.
 pub struct NetworkUsers<S: Default + Miniconf, T: Serialize> {
-    pub miniconf:
-        miniconf::MqttClient<S, NetworkReference, SystemTimer, 512>,
+    pub miniconf: miniconf::MqttClient<S, NetworkReference, SystemTimer, 512>,
     pub processor: NetworkProcessor,
     stream: DataStream,
     generator: Option<FrameGenerator>,


### PR DESCRIPTION
This PR updates Stabilizer to use miniconf 0.3, which automatically publishes the settings structure on startup over MQTT.

TODO:
- [x] Release `minimq` as a patched 0.5.1 version to incorporate handling of full network buffering.
- [x] Release idsp to support new miniconf versions, remove patch