### PR TITLE
Updating CHANGELOG to mention settings republish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Telemetry
 * RTT logging
+* Settings structures now automatically publish after a short delay on boot
 
 ### Changed
 


### PR DESCRIPTION
Adds a short changelog entry to mention settings republish on boot.