### PR TITLE
Updating RTIC to 1.0

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,12 +1,13 @@
 block_labels = [ "S-blocked" ]
 delete_merged_branches = true
 timeout_sec = 1200
+# keep MSRV in sync in ci.yaml, bors.toml, and setup.md
 status = [
   "style",
   "compile (stable)",
   "compile (stable, pounder_v1_1)",
-  "compile (1.52.0)",
-  "compile (1.52.0, pounder_v1_1)",
+  "compile (1.57.0)",
+  "compile (1.57.0, pounder_v1_1)",
   "doc",
   "HITL Run Status"
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     strategy:
       matrix:
-        toolchain: [stable, '1.52.0']
+        toolchain: [stable, '1.56.0']
         features: ['', pounder_v1_1]
         include:
           - toolchain: beta

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     strategy:
       matrix:
+        # keep MSRV in sync in ci.yaml, bors.toml, and setup.md
         toolchain: [stable, '1.57.0']
         features: ['', pounder_v1_1]
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     strategy:
       matrix:
-        toolchain: [stable, '1.56.0']
+        toolchain: [stable, '1.57.0']
         features: ['', pounder_v1_1]
         include:
           - toolchain: beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Const generics, bumping the MSRV to 1.51.0 ([#355](https://github.com/quartiq/stabilizer/pull/355) etc)
 * `lockin-internal` and `lockin-external` have been merged into `lockin` ([#352](https://github.com/quartiq/stabilizer/pull/352))
-* Set target CPU to cortex-m7, effectively bumping the MSRV to 1.52.0
+* Set target CPU to cortex-m7
 * Process routine can be executed from fast closely coupled memory with wide
   bus for faster execution ([#420](https://github.com/quartiq/stabilizer/pull/420))
 * Relicensed as MIT/Apache ([#419](https://github.com/quartiq/stabilizer/pull/419) [#416](https://github.com/quartiq/stabilizer/pull/416))
+* Minimum supported Rust version bumped to 1.57
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rtic"
-version = "0.6.0-rc.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248b2f20fd8f885f8fa802766ea3f076692eb8d57e611c8afd1b82d3000cfe9a"
+checksum = "daae9c453d0d5b467ebcdeae7aba537cb45a7de899930ad09f01c8dc42aa531f"
 dependencies = [
  "bare-metal 1.0.0",
  "cortex-m 0.7.4",
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rtic-macros"
-version = "0.6.0-rc.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683784a9ebcb2531233fd6d866ba98660bbc927b1028871bea6d4cee4c330c54"
+checksum = "7ba355d1639cf8df7c0658f01bd8952d11d49a029309118787eb54afc47a6cf8"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -277,6 +277,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "fugit"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e489f95411a50db661b18e072459bbdc084de522a8530e4709bef593bf3c18"
+dependencies = [
+ "gcd",
+]
+
+[[package]]
+name = "gcd"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37978dab2ca789938a83b2f8bc1ef32db6633af9051a6cd409eff72cbaaa79a"
+dependencies = [
+ "paste",
 ]
 
 [[package]]
@@ -651,24 +669,21 @@ dependencies = [
 
 [[package]]
 name = "rtic-core"
-version = "0.3.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd58a6949de8ff797a346a28d9f13f7b8f54fa61bb5e3cb0985a4efb497a5ef"
+checksum = "d9369355b04d06a3780ec0f51ea2d225624db777acbc60abd8ca4832da5c1a42"
 
 [[package]]
 name = "rtic-monotonic"
-version = "0.1.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d337abf8372869b326af4b0d612f82d934d6d2bcc700908c367a2c7e8db34ba7"
-dependencies = [
- "embedded-time",
-]
+checksum = "fb8b0b822d1a366470b9cea83a1d4e788392db763539dc4ba022bcc787fece82"
 
 [[package]]
 name = "rtic-syntax"
-version = "0.5.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a608b5c4d51aa5d6a9c0fb62ed716a5d7302391fdbaf116aad69606b8ba4cc6"
+checksum = "24b149ff3177daeee442bb81ef7867d20d3c1ffea8a0a94e46e0e4b876ec4be2"
 dependencies = [
  "indexmap",
  "proc-macro2",
@@ -836,6 +851,7 @@ dependencies = [
  "cortex-m-rt",
  "cortex-m-rtic",
  "embedded-hal",
+ "fugit",
  "heapless",
  "idsp",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,8 @@ keywords = ["ethernet", "stm32h7", "adc", "dac", "physics"]
 repository = "https://github.com/quartiq/stabilizer"
 readme = "README.md"
 documentation = "https://docs.rs/stabilizer/"
-edition = "2018"
+edition = "2021"
 exclude = [
-	".travis.yml",
 	".gitignore",
 	"doc/",
 	"doc/*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"
 rtt-target = { version = "0.3", features = ["cortex-m"] }
 serde = { version = "1.0", features = ["derive"], default-features = false }
 heapless = { version = "0.7", features = ["serde"] }
-cortex-m-rtic = "0.6.0-alpha.5"
+cortex-m-rtic = "1.0"
 embedded-hal = "0.2.6"
 nb = "1.0.0"
 asm-delay = "0.9.0"
@@ -49,6 +49,7 @@ serde-json-core = "0.4"
 mcp23017 = "1.0"
 mutex-trait = "0.2"
 minimq = "0.5.2"
+fugit = "0.3"
 
 # rtt-target bump
 [dependencies.rtt-logger]

--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -66,7 +66,7 @@ docker run -p 1883:1883 --name mosquitto -v ${pwd}/mosquitto.conf:/mosquitto/con
 ## Building
 
 1. Get and install [rustup](https://rustup.rs/) and use it to install a current stable Rust toolchain.
-    The minimum supported Rust version (MSRV) is 1.56.0 (2021 edition).
+    The minimum supported Rust version (MSRV) is 1.57.0 (2021 edition).
 1. Install target support
     ```bash
     rustup target add thumbv7em-none-eabihf

--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -66,7 +66,7 @@ docker run -p 1883:1883 --name mosquitto -v ${pwd}/mosquitto.conf:/mosquitto/con
 ## Building
 
 1. Get and install [rustup](https://rustup.rs/) and use it to install a current stable Rust toolchain.
-    The minimum supported Rust version (MSRV) is 1.52.0.
+    The minimum supported Rust version (MSRV) is 1.56.0 (2021 edition).
 1. Install target support
     ```bash
     rustup target add thumbv7em-none-eabihf

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -33,8 +33,8 @@ use core::sync::atomic::{fence, Ordering};
 
 use mutex_trait::prelude::*;
 
+use fugit::ExtU32;
 use idsp::iir;
-use rtic::time::duration::Extensions;
 use stabilizer::{
     hardware::{
         self,
@@ -441,7 +441,7 @@ mod app {
 
         // Schedule the telemetry task in the future.
         telemetry_task::Monotonic::spawn_after(
-            (telemetry_period as u32).seconds(),
+            (telemetry_period as u32).secs(),
         )
         .unwrap();
     }
@@ -451,7 +451,7 @@ mod app {
         c.shared
             .network
             .lock(|network| network.processor.handle_link());
-        ethernet_link::Monotonic::spawn_after(1u32.seconds()).unwrap();
+        ethernet_link::Monotonic::spawn_after(1u32.secs()).unwrap();
     }
 
     #[task(binds = ETH, priority = 1)]

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -35,8 +35,8 @@ use core::{
 
 use mutex_trait::prelude::*;
 
+use fugit::ExtU32;
 use idsp::{Accu, Complex, ComplexExt, Lockin, RPLL};
-use rtic::time::duration::Extensions;
 use stabilizer::{
     hardware::{
         self,
@@ -503,14 +503,14 @@ mod app {
         });
 
         // Schedule the telemetry task in the future.
-        telemetry::Monotonic::spawn_after((telemetry_period as u32).seconds())
+        telemetry::Monotonic::spawn_after((telemetry_period as u32).secs())
             .unwrap();
     }
 
     #[task(priority = 1, shared=[network])]
     fn ethernet_link(mut c: ethernet_link::Context) {
         c.shared.network.lock(|net| net.processor.handle_link());
-        ethernet_link::Monotonic::spawn_after(1u32.seconds()).unwrap();
+        ethernet_link::Monotonic::spawn_after(1u32.secs()).unwrap();
     }
 
     #[task(binds = ETH, priority = 1)]


### PR DESCRIPTION
This PR updates RTIC to 1.0

It also makes some modifications to the `Monotonic` implementation to address issues with `embedded-time` not being able to satisfy RTIC's requirements. `fugit` is now used for the rtic::Monotonic implmentation and `embedded-time` is used for libraries.

TODO:
- [x] Tested on Stabilizer hardware