### PR TITLE
Add static IP address as a build feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Optional specification of a static IP address ([#509](https://github.com/quartiq/stabilizer/pull/509))
 * Telemetry ([#341](https://github.com/quartiq/stabilizer/pull/341))
 * Logging via RTT (real time tracing) over SWD/JTAG instead of semihosting
   for fast and low-overhead debugging ([#393](https://github.com/quartiq/stabilizer/pull/393) [#391](https://github.com/quartiq/stabilizer/pull/391) [#358](https://github.com/quartiq/stabilizer/pull/358))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ branch = "feature/assume-init"
 [features]
 nightly = ["cortex-m/inline-asm"]
 pounder_v1_1 = [ ]
-static_ip = [ ]
 
 [profile.dev]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ branch = "feature/assume-init"
 [features]
 nightly = ["cortex-m/inline-asm"]
 pounder_v1_1 = [ ]
+static_ip = [ ]
 
 [profile.dev]
 codegen-units = 1

--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -27,6 +27,8 @@ Stabilizer supports 10Base-T or 100Base-T with Auto MDI-X.
 Stabilizer uses DHCP to obtain its network configuration information. Ensure there is a
 properly configured DHCP server running on the network segment that Stabilizer is
 connected to.
+Alternatively, a static IP can be enforced in the firmware build command by specifying
+the environmental variable `STATIC_IP` analogous to how a specific broker IP is set.
 
 > **Note:** If Stabilizer is connected directly to an Ubuntu system (for example using a USB-Ethernet dongle) 
 you can set the IPv4 settings of this Ethernet connection in the Ubuntu network settings to

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -690,7 +690,7 @@ pub fn setup(
 
         // Configure IP address according to DHCP socket availability
         let ip_addrs: smoltcp::wire::IpAddress = option_env!("STATIC_IP")
-            .unwrap_or("UNSPECIFIED")
+            .unwrap_or("0.0.0.0")
             .parse()
             .unwrap();
 
@@ -699,15 +699,7 @@ pub fn setup(
         let store =
             cortex_m::singleton!(: NetStorage = NetStorage::default()).unwrap();
 
-        store.ip_addrs[0] = match ip_addrs.is_unspecified() {
-            true => smoltcp::wire::IpCidr::new(
-                smoltcp::wire::IpAddress::Ipv4(
-                    smoltcp::wire::Ipv4Address::UNSPECIFIED,
-                ),
-                0,
-            ),
-            false => smoltcp::wire::IpCidr::new(ip_addrs, 24),
-        };
+        store.ip_addrs[0] = smoltcp::wire::IpCidr::new(ip_addrs, 24);
 
         let mut routes =
             smoltcp::iface::Routes::new(&mut store.routes_cache[..]);

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -23,20 +23,11 @@ const NUM_TCP_SOCKETS: usize = 4;
 const NUM_UDP_SOCKETS: usize = 1;
 const NUM_SOCKETS: usize = NUM_UDP_SOCKETS + NUM_TCP_SOCKETS;
 
-const IPADDR: [u8; 4] = [192, 168, 137, 17];
-
-// Omit DHCP socket, if static IP is used
-#[cfg(feature = "static_ip")]
-const NUM_DHCP_SOCKETS: usize = 0;
-#[cfg(not(feature = "static_ip"))]
-const NUM_DHCP_SOCKETS: usize = 1;
-
 pub struct NetStorage {
     pub ip_addrs: [smoltcp::wire::IpCidr; 1],
 
     // Note: There is an additional socket set item required for the DHCP socket.
-    pub sockets: [smoltcp::iface::SocketStorage<'static>;
-        NUM_SOCKETS + NUM_DHCP_SOCKETS],
+    pub sockets: [smoltcp::iface::SocketStorage<'static>; NUM_SOCKETS + 1],
     pub tcp_socket_storage: [TcpSocketStorage; NUM_TCP_SOCKETS],
     pub udp_socket_storage: [UdpSocketStorage; NUM_UDP_SOCKETS],
     pub neighbor_cache:
@@ -93,8 +84,7 @@ impl Default for NetStorage {
             )],
             neighbor_cache: [None; 8],
             routes_cache: [None; 8],
-            sockets: [smoltcp::iface::SocketStorage::EMPTY;
-                NUM_SOCKETS + NUM_DHCP_SOCKETS],
+            sockets: [smoltcp::iface::SocketStorage::EMPTY; NUM_SOCKETS + 1],
             tcp_socket_storage: [TcpSocketStorage::new(); NUM_TCP_SOCKETS],
             udp_socket_storage: [UdpSocketStorage::new(); NUM_UDP_SOCKETS],
         }
@@ -699,31 +689,25 @@ pub fn setup(
         unsafe { ethernet::enable_interrupt() };
 
         // Configure IP address according to DHCP socket availability
-        let ip_addrs: smoltcp::wire::IpCidr;
-        if NUM_DHCP_SOCKETS == 1 {
-            ip_addrs = smoltcp::wire::IpCidr::new(
-                smoltcp::wire::IpAddress::Ipv4(
-                    smoltcp::wire::Ipv4Address::UNSPECIFIED,
-                ),
-                0,
-            );
-        } else {
-            ip_addrs = smoltcp::wire::IpCidr::new(
-                smoltcp::wire::IpAddress::Ipv4(
-                    smoltcp::wire::Ipv4Address::new(
-                        IPADDR[0], IPADDR[1], IPADDR[2], IPADDR[3],
-                    ),
-                ),
-                24,
-            );
-        }
+        let ip_addrs: smoltcp::wire::IpAddress = option_env!("STATIC_IP")
+            .unwrap_or("UNSPECIFIED")
+            .parse()
+            .unwrap();
 
         // Note(unwrap): The hardware configuration function is only allowed to be called once.
         // Unwrapping is intended to panic if called again to prevent re-use of global memory.
         let store =
             cortex_m::singleton!(: NetStorage = NetStorage::default()).unwrap();
 
-        store.ip_addrs[0] = ip_addrs;
+        store.ip_addrs[0] = match ip_addrs.is_unspecified() {
+            true => smoltcp::wire::IpCidr::new(
+                smoltcp::wire::IpAddress::Ipv4(
+                    smoltcp::wire::Ipv4Address::UNSPECIFIED,
+                ),
+                0,
+            ),
+            false => smoltcp::wire::IpCidr::new(ip_addrs, 24),
+        };
 
         let mut routes =
             smoltcp::iface::Routes::new(&mut store.routes_cache[..]);
@@ -744,7 +728,7 @@ pub fn setup(
         .routes(routes)
         .finalize();
 
-        if NUM_DHCP_SOCKETS == 1 {
+        if ip_addrs.is_unspecified() {
             interface.add_socket(smoltcp::socket::Dhcpv4Socket::new());
         }
 


### PR DESCRIPTION
In some cases it might be advantageous to set a static IP address for Stabilizer e.g. if it is used in an embedded environment that doesn't support DHCP or troubleshooting problems with DHCP negotiation.
This PR add this functionality as a build feature.