### PR TITLE
redesign stream pool/maybeuninit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,8 +342,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heapless"
-version = "0.7.7"
-source = "git+https://github.com/quartiq/heapless.git?branch=feature/assume-init#11a3ef7207683f1538969e2dd89cd4c7281c243e"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d076121838e03f862871315477528debffdb7462fb229216ecef91b1a3eb31eb"
 dependencies = [
  "atomic-polyfill",
  "hash32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ cortex-m-rt = { version = "0.7", features = ["device"] }
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"] }
 rtt-target = { version = "0.3", features = ["cortex-m"] }
 serde = { version = "1.0", features = ["derive"], default-features = false }
-heapless = { version = "0.7", features = ["serde"] }
+heapless = { version = "0.7.10", features = ["serde"] }
 cortex-m-rtic = "1.0"
 embedded-hal = "0.2.7"
 nb = "1.0.0"
@@ -56,10 +56,6 @@ mono-clock = "0.1"
 [dependencies.stm32h7xx-hal]
 features = ["stm32h743v", "rt", "unproven", "ethernet", "xspi"]
 version = "0.11.0"
-
-[patch.crates-io.heapless]
-git = "https://github.com/quartiq/heapless.git"
-branch = "feature/assume-init"
 
 [features]
 nightly = ["cortex-m/inline-asm"]

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -29,6 +29,7 @@
 #![no_std]
 #![no_main]
 
+use core::mem::MaybeUninit;
 use core::sync::atomic::{fence, Ordering};
 
 use fugit::ExtU64;
@@ -353,7 +354,8 @@ mod app {
                     }
 
                     // Stream the data.
-                    const N: usize = BATCH_SIZE * core::mem::size_of::<u16>();
+                    const N: usize = BATCH_SIZE * core::mem::size_of::<i16>()
+                        / core::mem::size_of::<MaybeUninit<u32>>();
                     generator.add::<_, { N * 4 }>(|buf| {
                         for (data, buf) in adc_samples
                             .iter()
@@ -362,14 +364,13 @@ mod app {
                         {
                             let data = unsafe {
                                 core::slice::from_raw_parts(
-                                    data.as_ptr() as *const u8,
+                                    data.as_ptr() as *const MaybeUninit<u32>,
                                     N,
                                 )
                             };
                             buf.copy_from_slice(data)
                         }
                     });
-
                     // Update telemetry measurements.
                     telemetry.adcs = [
                         AdcCode(adc_samples[0][0]),

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -30,6 +30,7 @@
 
 use core::{
     convert::TryFrom,
+    mem::MaybeUninit,
     sync::atomic::{fence, Ordering},
 };
 
@@ -421,7 +422,8 @@ mod app {
                 }
 
                 // Stream the data.
-                const N: usize = BATCH_SIZE * core::mem::size_of::<u16>();
+                const N: usize = BATCH_SIZE * core::mem::size_of::<i16>()
+                    / core::mem::size_of::<MaybeUninit<u32>>();
                 generator.add::<_, { N * 4 }>(|buf| {
                     for (data, buf) in adc_samples
                         .iter()
@@ -430,7 +432,7 @@ mod app {
                     {
                         let data = unsafe {
                             core::slice::from_raw_parts(
-                                data.as_ptr() as *const u8,
+                                data.as_ptr() as *const MaybeUninit<u32>,
                                 N,
                             )
                         };

--- a/src/net/data_stream.rs
+++ b/src/net/data_stream.rs
@@ -156,7 +156,7 @@ impl StreamFrame {
         let mut buffer = buffer.init([MaybeUninit::uninit(); FRAME_SIZE]);
         let magic = MAGIC.to_le_bytes();
         buffer[0].write(u32::from_le_bytes([
-            batch_size, format_id, magic[0], magic[1],
+            magic[0], magic[1], format_id, batch_size,
         ]));
         buffer[1].write(sequence_number.to_le());
         Self {

--- a/src/net/data_stream.rs
+++ b/src/net/data_stream.rs
@@ -22,36 +22,42 @@
 //! # Example
 //! A sample Python script is available in `scripts/stream_throughput.py` to demonstrate reception
 //! of livestreamed data.
-use heapless::spsc::{Consumer, Producer, Queue};
+use core::mem::MaybeUninit;
+use heapless::{
+    pool::{Box, Init, Pool, Uninit},
+    spsc::{Consumer, Producer, Queue},
+};
 use miniconf::MiniconfAtomic;
 use num_enum::IntoPrimitive;
 use serde::{Deserialize, Serialize};
 use smoltcp_nal::embedded_nal::{IpAddr, Ipv4Addr, SocketAddr, UdpClientStack};
 
-use heapless::pool::{Box, Init, Pool, Uninit};
-
 use super::NetworkReference;
 
 const MAGIC_WORD: u16 = 0x057B;
 
-// The size of the header, calculated in bytes.
+// The size of the header, calculated in words.
 // The header has a 16-bit magic word, an 8-bit format, 8-bit batch-size, and 32-bit sequence
-// number, which corresponds to 8 bytes total.
-const HEADER_SIZE: usize = 8;
+// number, which corresponds to 8 bytes or 2 words total.
+const HEADER_SIZE: usize = 2;
 
 // The number of frames that can be buffered.
 const FRAME_COUNT: usize = 4;
 
-// The size of each livestream frame in bytes.
-const FRAME_SIZE: usize = 1024 + HEADER_SIZE;
+// The size of each livestream frame in words.
+const FRAME_SIZE: usize = 256 + HEADER_SIZE;
 
 // The size of the frame queue must be at least as large as the number of frame buffers. Every
 // allocated frame buffer should fit in the queue.
 const FRAME_QUEUE_SIZE: usize = FRAME_COUNT * 2;
 
 // Static storage used for a heapless::Pool of frame buffers.
-static mut FRAME_DATA: [u8; FRAME_SIZE * FRAME_COUNT] =
-    [0; FRAME_SIZE * FRAME_COUNT];
+static mut FRAME_DATA: [u8; core::mem::size_of::<u32>()
+    * FRAME_SIZE
+    * FRAME_COUNT] =
+    [0; core::mem::size_of::<u32>() * FRAME_SIZE * FRAME_COUNT];
+
+type Frame = [MaybeUninit<u32>; FRAME_SIZE];
 
 /// Represents the destination for the UDP stream to send data to.
 ///
@@ -120,8 +126,7 @@ pub fn setup_streaming(
             .unwrap();
     let (producer, consumer) = queue.split();
 
-    let frame_pool =
-        cortex_m::singleton!(: Pool<[u8; FRAME_SIZE]>= Pool::new()).unwrap();
+    let frame_pool = cortex_m::singleton!(: Pool<Frame> = Pool::new()).unwrap();
 
     // Note(unsafe): We guarantee that FRAME_DATA is only accessed once in this function.
     let memory = unsafe { &mut FRAME_DATA };
@@ -136,22 +141,24 @@ pub fn setup_streaming(
 
 #[derive(Debug)]
 struct StreamFrame {
-    buffer: Box<[u8; FRAME_SIZE], Init>,
+    buffer: Box<Frame, Init>,
     offset: usize,
 }
 
 impl StreamFrame {
     pub fn new(
-        buffer: Box<[u8; FRAME_SIZE], Uninit>,
+        buffer: Box<Frame, Uninit>,
         format: u8,
         buffer_size: u8,
         sequence_number: u32,
     ) -> Self {
-        let mut buffer = unsafe { buffer.assume_init() };
-        buffer[0..2].copy_from_slice(&MAGIC_WORD.to_ne_bytes());
-        buffer[2] = format;
-        buffer[3] = buffer_size;
-        buffer[4..8].copy_from_slice(&sequence_number.to_ne_bytes());
+        let mut buffer = buffer.init([MaybeUninit::uninit(); FRAME_SIZE]);
+        let magic = MAGIC_WORD.to_ne_bytes();
+        buffer[0].write(
+            u32::from_ne_bytes([magic[0], magic[1], format, buffer_size])
+                .to_be(),
+        );
+        buffer[1].write(sequence_number.to_be());
         Self {
             buffer,
             offset: HEADER_SIZE,
@@ -160,7 +167,7 @@ impl StreamFrame {
 
     pub fn add_batch<F, const T: usize>(&mut self, mut f: F)
     where
-        F: FnMut(&mut [u8]),
+        F: FnMut(&mut [MaybeUninit<u32>]),
     {
         f(&mut self.buffer[self.offset..self.offset + T]);
 
@@ -171,7 +178,7 @@ impl StreamFrame {
         self.offset + T > self.buffer.len()
     }
 
-    pub fn finish(&mut self) -> &[u8] {
+    pub fn finish(&self) -> &[MaybeUninit<u32>] {
         &self.buffer[..self.offset]
     }
 }
@@ -179,7 +186,7 @@ impl StreamFrame {
 /// The data generator for a stream.
 pub struct FrameGenerator {
     queue: Producer<'static, StreamFrame, FRAME_QUEUE_SIZE>,
-    pool: &'static Pool<[u8; FRAME_SIZE]>,
+    pool: &'static Pool<Frame>,
     current_frame: Option<StreamFrame>,
     sequence_number: u32,
     format: u8,
@@ -189,7 +196,7 @@ pub struct FrameGenerator {
 impl FrameGenerator {
     fn new(
         queue: Producer<'static, StreamFrame, FRAME_QUEUE_SIZE>,
-        pool: &'static Pool<[u8; FRAME_SIZE]>,
+        pool: &'static Pool<Frame>,
     ) -> Self {
         Self {
             queue,
@@ -223,7 +230,7 @@ impl FrameGenerator {
     ///   be the size of the `T` template argument.
     pub fn add<F, const T: usize>(&mut self, f: F)
     where
-        F: FnMut(&mut [u8]),
+        F: FnMut(&mut [MaybeUninit<u32>]),
     {
         let sequence_number = self.sequence_number;
         self.sequence_number = self.sequence_number.wrapping_add(1);
@@ -264,7 +271,7 @@ pub struct DataStream {
     stack: NetworkReference,
     socket: Option<<NetworkReference as UdpClientStack>::UdpSocket>,
     queue: Consumer<'static, StreamFrame, FRAME_QUEUE_SIZE>,
-    frame_pool: &'static Pool<[u8; FRAME_SIZE]>,
+    frame_pool: &'static Pool<Frame>,
     remote: SocketAddr,
 }
 
@@ -278,7 +285,7 @@ impl DataStream {
     fn new(
         stack: NetworkReference,
         consumer: Consumer<'static, StreamFrame, FRAME_QUEUE_SIZE>,
-        frame_pool: &'static Pool<[u8; FRAME_SIZE]>,
+        frame_pool: &'static Pool<Frame>,
     ) -> Self {
         Self {
             stack,
@@ -343,9 +350,17 @@ impl DataStream {
                 }
             }
             Some(handle) => {
-                if let Some(mut frame) = self.queue.dequeue() {
+                if let Some(frame) = self.queue.dequeue() {
                     // Transmit the frame and return it to the pool.
-                    self.stack.send(handle, frame.finish()).ok();
+                    let buf = frame.finish();
+                    let data = unsafe {
+                        core::slice::from_raw_parts(
+                            buf.as_ptr() as *const u8,
+                            buf.len()
+                                * core::mem::size_of::<MaybeUninit<u32>>(),
+                        )
+                    };
+                    self.stack.send(handle, data).ok();
                     self.frame_pool.free(frame.buffer)
                 }
             }

--- a/src/net/data_stream.rs
+++ b/src/net/data_stream.rs
@@ -154,11 +154,11 @@ impl StreamFrame {
         sequence_number: u32,
     ) -> Self {
         let mut buffer = buffer.init([MaybeUninit::uninit(); FRAME_SIZE]);
-        let magic = MAGIC.to_le_bytes();
+        let magic = MAGIC.to_ne_bytes();
         buffer[0].write(u32::from_le_bytes([
             magic[0], magic[1], format_id, batch_size,
         ]));
-        buffer[1].write(sequence_number.to_le());
+        buffer[1].write(sequence_number);
         Self {
             buffer,
             offset: HEADER_SIZE,


### PR DESCRIPTION
* Use mainline heapless
* CHange from u8 to u32 item size for significantly improved codegen
* Let the pool allocation be an array of MaybeUninit<u32>
* Properly unitialize it with a MaybeUninit::uninit() array
* Use the write() API for the header
* Do the rest via unsafe from_raw_parts as it would always be unsafe

Re #454 