### PR TITLE
Move static IP entry to unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Added
+
+* Optional specification of a static IP address ([#509](https://github.com/quartiq/stabilizer/pull/509))
+
 ### Removed
 ### Changed
 ### Fixed
@@ -16,7 +19,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-* Optional specification of a static IP address ([#509](https://github.com/quartiq/stabilizer/pull/509))
 * Telemetry ([#341](https://github.com/quartiq/stabilizer/pull/341))
 * Logging via RTT (real time tracing) over SWD/JTAG instead of semihosting
   for fast and low-overhead debugging ([#393](https://github.com/quartiq/stabilizer/pull/393) [#391](https://github.com/quartiq/stabilizer/pull/391) [#358](https://github.com/quartiq/stabilizer/pull/358))


### PR DESCRIPTION
Corrected the changelog as static IP entry went to release v0.6.0 by mistake