### PR TITLE
Derive copy&clone for UdpSocketStorage

### DIFF
--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -36,6 +36,7 @@ pub struct NetStorage {
         [Option<(smoltcp::wire::IpCidr, smoltcp::iface::Route)>; 8],
 }
 
+#[derive(Copy, Clone)]
 pub struct UdpSocketStorage {
     rx_storage: [u8; 1024],
     tx_storage: [u8; 2048],


### PR DESCRIPTION
Deriving copy and clone for UdpSocketStorage is needed in order to have multiple UDP sockets, analogously to TcpSocketStorage 