### PR TITLE
Allow public access to stack in NetworkProcessor

### DIFF
--- a/src/net/network_processor.rs
+++ b/src/net/network_processor.rs
@@ -8,7 +8,7 @@ use crate::hardware::EthernetPhy;
 
 /// Processor for managing network hardware.
 pub struct NetworkProcessor {
-    stack: NetworkReference,
+    pub stack: NetworkReference,
     phy: EthernetPhy,
     network_was_reset: bool,
 }


### PR DESCRIPTION
Publich access is needed in order to retrieve Stabilizer's IP address assigned over DHCP