### PR TITLE
Updating Stabilizer to utilize Miniconf 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "derive_miniconf"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf0746ffedecccb7abefca46c550a49c50ee40fa5fd2555cfa115a1a109324a"
+checksum = "9c587b2363b948e4035fc1e8ac33278dc6fda9a40190a22abe55839fcaeda161"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -356,8 +356,7 @@ dependencies = [
 [[package]]
 name = "idsp"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f927d7401864366355cf291c4407d5ea321cbcc40362623b06a00e41d2217be"
+source = "git+https://github.com/quartiq/idsp?rev=00967f01ef2e11af3d3c5a4e9e7815d59dba3806#00967f01ef2e11af3d3c5a4e9e7815d59dba3806"
 dependencies = [
  "miniconf",
  "num-complex 0.4.0",
@@ -428,9 +427,9 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "miniconf"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bebe771bb9b1d6ab2735374465002f6e15db45c8d863b8b1873881e98d6da22"
+checksum = "76ba55ad97c893ffe5293ea3c0d19c505e164f6628ead64d25dada828deb3673"
 dependencies = [
  "derive_miniconf",
  "heapless",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ num_enum = { version = "0.5.6", default-features = false }
 paste = "1"
 idsp = "0.7.1"
 ad9959 = { path = "ad9959", version = "0.1.0" }
-miniconf = "0.3"
+miniconf = "0.5"
 smoltcp-nal = { version = "0.2", features = ["shared-stack"] }
 serde-json-core = "0.4"
 mcp23017 = "1.0"
@@ -55,6 +55,11 @@ fugit = "0.3"
 rtt-logger = "0.2"
 systick-monotonic = "1.0"
 mono-clock = "0.1"
+
+[patch.crates-io.idsp]
+# Patched to utilize Miniconf 0.5
+git = "https://github.com/quartiq/idsp"
+rev = "00967f01ef2e11af3d3c5a4e9e7815d59dba3806"
 
 [dependencies.stm32h7xx-hal]
 features = ["stm32h743v", "rt", "unproven", "ethernet", "xspi"]

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -44,7 +44,7 @@ pub enum NetworkState {
     NoChange,
 }
 /// A structure of Stabilizer's default network users.
-pub struct NetworkUsers<S: Default + Miniconf, T: Serialize> {
+pub struct NetworkUsers<S: Default + Miniconf + Clone, T: Serialize> {
     pub miniconf: miniconf::MqttClient<S, NetworkReference, SystemTimer, 512>,
     pub processor: NetworkProcessor,
     stream: DataStream,
@@ -54,7 +54,7 @@ pub struct NetworkUsers<S: Default + Miniconf, T: Serialize> {
 
 impl<S, T> NetworkUsers<S, T>
 where
-    S: Default + Miniconf,
+    S: Default + Miniconf + Clone,
     T: Serialize,
 {
     /// Construct Stabilizer's default network users.
@@ -92,6 +92,7 @@ where
             &prefix,
             broker,
             clock,
+            S::default(),
         )
         .unwrap();
 


### PR DESCRIPTION
This PR upgrades Miniconf to v0.5.0.