### PR TITLE
Fixing batch size 1 calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Minimum supported Rust version bumped to 1.59
 
 ### Fixed
+* Fixed panics when using a batch size of 1 ([#540](https://github.com/quartiq/stabilizer/issues/540))
 
 ## [v0.6.0] - 2022-02-11
 

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -352,7 +352,7 @@ mod app {
 
                     // Stream the data.
                     const N: usize = BATCH_SIZE * core::mem::size_of::<i16>()
-                        / core::mem::size_of::<MaybeUninit<u32>>();
+                        / core::mem::size_of::<MaybeUninit<u8>>();
                     generator.add::<_, { N * 4 }>(|buf| {
                         for (data, buf) in adc_samples
                             .iter()
@@ -361,7 +361,7 @@ mod app {
                         {
                             let data = unsafe {
                                 core::slice::from_raw_parts(
-                                    data.as_ptr() as *const MaybeUninit<u32>,
+                                    data.as_ptr() as *const MaybeUninit<u8>,
                                     N,
                                 )
                             };

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -422,7 +422,7 @@ mod app {
 
                 // Stream the data.
                 const N: usize = BATCH_SIZE * core::mem::size_of::<i16>()
-                    / core::mem::size_of::<MaybeUninit<u32>>();
+                    / core::mem::size_of::<MaybeUninit<u8>>();
                 generator.add::<_, { N * 4 }>(|buf| {
                     for (data, buf) in adc_samples
                         .iter()
@@ -431,7 +431,7 @@ mod app {
                     {
                         let data = unsafe {
                             core::slice::from_raw_parts(
-                                data.as_ptr() as *const MaybeUninit<u32>,
+                                data.as_ptr() as *const MaybeUninit<u8>,
                                 N,
                             )
                         };


### PR DESCRIPTION
This PR fixes #540 by refactoring the stream frames to use `u8` as the underlying type. There was an integer division error when using a batch size of 1 when using `u32` container types, as a single sample cannot completely fill the `u32` container.

We can alternatively use a container type of `u16`, but I don't know if we gain anything by using a larger container, so I just opted for `u8` as it's byte-level representation.