### PR TITLE
pounder: invert feature: pounder_v1_1 -> not(pounder_v1_0)

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -5,9 +5,7 @@ timeout_sec = 1200
 status = [
   "style",
   "compile (stable)",
-  "compile (stable, pounder_v1_1)",
   "compile (1.59.0)",
-  "compile (1.59.0, pounder_v1_1)",
   "doc",
   "HITL Run Status"
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       matrix:
         # keep MSRV in sync in ci.yaml, bors.toml, and setup.md
         toolchain: [stable, '1.59.0']
-        features: ['', pounder_v1_1]
+        features: ['']
         include:
           - toolchain: beta
             features: ''

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ version = "0.12.2"
 
 [features]
 nightly = [ ]
-pounder_v1_1 = [ ]
+pounder_v1_0 = [ ]
 
 [profile.dev]
 codegen-units = 1

--- a/src/hardware/pounder/mod.rs
+++ b/src/hardware/pounder/mod.rs
@@ -7,7 +7,7 @@ pub mod dds_output;
 pub mod hrtimer;
 pub mod rf_power;
 
-#[cfg(feature = "pounder_v1_1")]
+#[cfg(not(feature = "pounder_v1_0"))]
 pub mod timestamp;
 
 pub enum GpioPin {

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -116,7 +116,7 @@ pub struct PounderDevices {
     pub pounder: pounder::PounderDevices,
     pub dds_output: DdsOutput,
 
-    #[cfg(feature = "pounder_v1_1")]
+    #[cfg(not(feature = "pounder_v1_0"))]
     pub timestamper: pounder::timestamp::Timestamper,
 }
 
@@ -821,9 +821,9 @@ pub fn setup(
                 pounder::QspiInterface::new(qspi).unwrap()
             };
 
-            #[cfg(feature = "pounder_v1_1")]
+            #[cfg(not(feature = "pounder_v1_0"))]
             let reset_pin = gpiog.pg6.into_push_pull_output();
-            #[cfg(not(feature = "pounder_v1_1"))]
+            #[cfg(feature = "pounder_v1_0")]
             let reset_pin = gpioa.pa0.into_push_pull_output();
 
             let mut io_update = gpiog.pg7.into_push_pull_output();
@@ -889,7 +889,7 @@ pub fn setup(
             DdsOutput::new(qspi, io_update_trigger, config)
         };
 
-        #[cfg(feature = "pounder_v1_1")]
+        #[cfg(not(feature = "pounder_v1_0"))]
         let pounder_stamper = {
             log::info!("Assuming Pounder v1.1 or later");
             let etr_pin = gpioa.pa0.into_alternate();
@@ -927,7 +927,7 @@ pub fn setup(
             pounder: pounder_devices,
             dds_output,
 
-            #[cfg(feature = "pounder_v1_1")]
+            #[cfg(not(feature = "pounder_v1_0"))]
             timestamper: pounder_stamper,
         })
     } else {


### PR DESCRIPTION
Rationale: later versions are expected to maintain compatibility with
not(pounder_v1_0), else will have to implement their own feature flags.
