### PR TITLE
Feature/shared adc channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,6 +879,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spinning"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stabilizer"
 version = "0.6.0"
 dependencies = [
@@ -905,6 +914,7 @@ dependencies = [
  "serde",
  "serde-json-core",
  "smoltcp-nal",
+ "spinning",
  "stm32h7xx-hal",
  "systick-monotonic",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,15 +879,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spinning"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "stabilizer"
 version = "0.6.0"
 dependencies = [
@@ -914,7 +905,7 @@ dependencies = [
  "serde",
  "serde-json-core",
  "smoltcp-nal",
- "spinning",
+ "spin",
  "stm32h7xx-hal",
  "systick-monotonic",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ fugit = "0.3"
 rtt-logger = "0.2"
 systick-monotonic = "1.0"
 mono-clock = "0.1"
-spinning = { version = "0.1", default-features = false }
+spin = { version = "0.9", default-features = false, features = ["spin_mutex"]}
 
 [dependencies.stm32h7xx-hal]
 features = ["stm32h743v", "rt", "ethernet", "xspi"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ fugit = "0.3"
 rtt-logger = "0.2"
 systick-monotonic = "1.0"
 mono-clock = "0.1"
+spinning = { version = "0.1", default-features = false }
 
 [dependencies.stm32h7xx-hal]
 features = ["stm32h743v", "rt", "ethernet", "xspi"]

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -9,6 +9,7 @@ pub mod design_parameters;
 pub mod input_stamper;
 pub mod pounder;
 pub mod setup;
+pub mod shared_adc;
 pub mod signal_generator;
 pub mod timers;
 

--- a/src/hardware/pounder/mod.rs
+++ b/src/hardware/pounder/mod.rs
@@ -15,37 +15,37 @@ pub mod timestamp;
 #[derive(Debug, Copy, Clone, TryFromPrimitive)]
 #[repr(u8)]
 pub enum GpioPin {
-Led4Green = 0,
-Led5Red = 1,
-Led6Green = 2,
-Led7Red = 3,
-Led8Green = 4,
-Led9Red = 5,
-AttLe0 = 8,
-AttLe1 = 8 + 1,
-AttLe2 = 8 + 2,
-AttLe3 = 8 + 3,
-AttRstN = 8 + 5,
-OscEnN = 8 + 6,
-ExtClkSel = 8 + 7,
+    Led4Green = 0,
+    Led5Red = 1,
+    Led6Green = 2,
+    Led7Red = 3,
+    Led8Green = 4,
+    Led9Red = 5,
+    AttLe0 = 8,
+    AttLe1 = 8 + 1,
+    AttLe2 = 8 + 2,
+    AttLe3 = 8 + 3,
+    AttRstN = 8 + 5,
+    OscEnN = 8 + 6,
+    ExtClkSel = 8 + 7,
 }
 
 #[derive(Debug, Copy, Clone)]
 pub enum Error {
-Spi,
-I2c,
-Qspi(hal::xspi::QspiError),
-Bounds,
-InvalidAddress,
-InvalidChannel,
-Adc,
-InvalidState,
+    Spi,
+    I2c,
+    Qspi(hal::xspi::QspiError),
+    Bounds,
+    InvalidAddress,
+    InvalidChannel,
+    Adc,
+    InvalidState,
 }
 
 impl From<hal::xspi::QspiError> for Error {
-fn from(e: hal::xspi::QspiError) -> Error {
-    Error::Qspi(e)
-}
+    fn from(e: hal::xspi::QspiError) -> Error {
+        Error::Qspi(e)
+    }
 }
 
 /// The numerical value (discriminant) of the Channel enum is the index in the attenuator shift
@@ -53,263 +53,229 @@ fn from(e: hal::xspi::QspiError) -> Error {
 #[derive(Debug, Copy, Clone)]
 #[allow(dead_code)]
 pub enum Channel {
-In0 = 0,
-Out0 = 1,
-In1 = 2,
-Out1 = 3,
+    In0 = 0,
+    Out0 = 1,
+    In1 = 2,
+    Out1 = 3,
 }
 
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 pub struct DdsChannelState {
-pub phase_offset: f32,
-pub frequency: f32,
-pub amplitude: f32,
-pub enabled: bool,
+    pub phase_offset: f32,
+    pub frequency: f32,
+    pub amplitude: f32,
+    pub enabled: bool,
 }
 
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 pub struct ChannelState {
-pub parameters: DdsChannelState,
-pub attenuation: f32,
+    pub parameters: DdsChannelState,
+    pub attenuation: f32,
 }
 
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 pub struct InputChannelState {
-pub attenuation: f32,
-pub power: f32,
-pub mixer: DdsChannelState,
+    pub attenuation: f32,
+    pub power: f32,
+    pub mixer: DdsChannelState,
 }
 
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 pub struct OutputChannelState {
-pub attenuation: f32,
-pub channel: DdsChannelState,
+    pub attenuation: f32,
+    pub channel: DdsChannelState,
 }
 
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 pub struct DdsClockConfig {
-pub multiplier: u8,
-pub reference_clock: f32,
-pub external_clock: bool,
+    pub multiplier: u8,
+    pub reference_clock: f32,
+    pub external_clock: bool,
 }
 
 impl From<Channel> for ad9959::Channel {
-/// Translate pounder channels to DDS output channels.
-fn from(other: Channel) -> Self {
-    match other {
-        Channel::In0 => Self::TWO,
-        Channel::In1 => Self::FOUR,
-        Channel::Out0 => Self::ONE,
-        Channel::Out1 => Self::THREE,
+    /// Translate pounder channels to DDS output channels.
+    fn from(other: Channel) -> Self {
+        match other {
+            Channel::In0 => Self::TWO,
+            Channel::In1 => Self::FOUR,
+            Channel::Out0 => Self::ONE,
+            Channel::Out1 => Self::THREE,
+        }
     }
-}
 }
 
 /// A structure for the QSPI interface for the DDS.
 pub struct QspiInterface {
-pub qspi: hal::xspi::Qspi<hal::stm32::QUADSPI>,
-mode: ad9959::Mode,
-streaming: bool,
+    pub qspi: hal::xspi::Qspi<hal::stm32::QUADSPI>,
+    mode: ad9959::Mode,
+    streaming: bool,
 }
 
 impl QspiInterface {
-/// Initialize the QSPI interface.
-///
-/// Args:
-/// * `qspi` - The QSPI peripheral driver.
-pub fn new(
-    mut qspi: hal::xspi::Qspi<hal::stm32::QUADSPI>,
-) -> Result<Self, Error> {
-    // This driver only supports operation in 4-bit mode due to bus inconsistencies between the
-    // QSPI peripheral and the DDS. Instead, we will bit-bang communications in
-    // single-bit-two-wire to the DDS to configure it to 4-bit operation.
-    qspi.configure_mode(hal::xspi::QspiMode::FourBit)?;
-    Ok(Self {
-        qspi,
-        mode: ad9959::Mode::SingleBitTwoWire,
-        streaming: false,
-    })
-}
-
-pub fn start_stream(&mut self) -> Result<(), Error> {
-    self.qspi.is_busy()?;
-
-    // Configure QSPI for infinite transaction mode using only a data phase (no instruction or
-    // address).
-    let qspi_regs = unsafe { &*hal::stm32::QUADSPI::ptr() };
-    qspi_regs.fcr.modify(|_, w| w.ctcf().set_bit());
-
-    unsafe {
-        qspi_regs.dlr.write(|w| w.dl().bits(0xFFFF_FFFF));
-        qspi_regs.ccr.modify(|_, w| {
-            w.imode().bits(0).fmode().bits(0).admode().bits(0)
-        });
+    /// Initialize the QSPI interface.
+    ///
+    /// Args:
+    /// * `qspi` - The QSPI peripheral driver.
+    pub fn new(
+        mut qspi: hal::xspi::Qspi<hal::stm32::QUADSPI>,
+    ) -> Result<Self, Error> {
+        // This driver only supports operation in 4-bit mode due to bus inconsistencies between the
+        // QSPI peripheral and the DDS. Instead, we will bit-bang communications in
+        // single-bit-two-wire to the DDS to configure it to 4-bit operation.
+        qspi.configure_mode(hal::xspi::QspiMode::FourBit)?;
+        Ok(Self {
+            qspi,
+            mode: ad9959::Mode::SingleBitTwoWire,
+            streaming: false,
+        })
     }
 
-    self.streaming = true;
+    pub fn start_stream(&mut self) -> Result<(), Error> {
+        self.qspi.is_busy()?;
 
-    Ok(())
-}
+        // Configure QSPI for infinite transaction mode using only a data phase (no instruction or
+        // address).
+        let qspi_regs = unsafe { &*hal::stm32::QUADSPI::ptr() };
+        qspi_regs.fcr.modify(|_, w| w.ctcf().set_bit());
+
+        unsafe {
+            qspi_regs.dlr.write(|w| w.dl().bits(0xFFFF_FFFF));
+            qspi_regs.ccr.modify(|_, w| {
+                w.imode().bits(0).fmode().bits(0).admode().bits(0)
+            });
+        }
+
+        self.streaming = true;
+
+        Ok(())
+    }
 }
 
 impl ad9959::Interface for QspiInterface {
-type Error = Error;
+    type Error = Error;
 
-/// Configure the operations mode of the interface.
-///
-/// Args:
-/// * `mode` - The newly desired operational mode.
-fn configure_mode(&mut self, mode: ad9959::Mode) -> Result<(), Error> {
-    self.mode = mode;
+    /// Configure the operations mode of the interface.
+    ///
+    /// Args:
+    /// * `mode` - The newly desired operational mode.
+    fn configure_mode(&mut self, mode: ad9959::Mode) -> Result<(), Error> {
+        self.mode = mode;
 
-    Ok(())
-}
-
-/// Write data over QSPI to the DDS.
-///
-/// Args:
-/// * `addr` - The address to write over QSPI to the DDS.
-/// * `data` - The data to write.
-fn write(&mut self, addr: u8, data: &[u8]) -> Result<(), Error> {
-    if (addr & 0x80) != 0 {
-        return Err(Error::InvalidAddress);
+        Ok(())
     }
 
-    // The QSPI interface implementation always operates in 4-bit mode because the AD9959 uses
-    // IO3 as SYNC_IO in some output modes. In order for writes to be successful, SYNC_IO must
-    // be driven low. However, the QSPI peripheral forces IO3 high when operating in 1 or 2 bit
-    // modes. As a result, any writes while in single- or dual-bit modes has to instead write
-    // the data encoded into 4-bit QSPI data so that IO3 can be driven low.
-    match self.mode {
-        ad9959::Mode::SingleBitTwoWire => {
-            // Encode the data into a 4-bit QSPI pattern.
+    /// Write data over QSPI to the DDS.
+    ///
+    /// Args:
+    /// * `addr` - The address to write over QSPI to the DDS.
+    /// * `data` - The data to write.
+    fn write(&mut self, addr: u8, data: &[u8]) -> Result<(), Error> {
+        if (addr & 0x80) != 0 {
+            return Err(Error::InvalidAddress);
+        }
 
-            // In 4-bit mode, we can send 2 bits of address and data per byte transfer. As
-            // such, we need at least 4x more bytes than the length of data. To avoid dynamic
-            // allocation, we assume the maximum transaction length for single-bit-two-wire is
-            // 2 bytes.
-            let mut encoded_data: [u8; 12] = [0; 12];
+        // The QSPI interface implementation always operates in 4-bit mode because the AD9959 uses
+        // IO3 as SYNC_IO in some output modes. In order for writes to be successful, SYNC_IO must
+        // be driven low. However, the QSPI peripheral forces IO3 high when operating in 1 or 2 bit
+        // modes. As a result, any writes while in single- or dual-bit modes has to instead write
+        // the data encoded into 4-bit QSPI data so that IO3 can be driven low.
+        match self.mode {
+            ad9959::Mode::SingleBitTwoWire => {
+                // Encode the data into a 4-bit QSPI pattern.
 
-            if (data.len() * 4) > (encoded_data.len() - 4) {
-                return Err(Error::Bounds);
-            }
+                // In 4-bit mode, we can send 2 bits of address and data per byte transfer. As
+                // such, we need at least 4x more bytes than the length of data. To avoid dynamic
+                // allocation, we assume the maximum transaction length for single-bit-two-wire is
+                // 2 bytes.
+                let mut encoded_data: [u8; 12] = [0; 12];
 
-            // Encode the address into the first 4 bytes.
-            for address_bit in 0..8 {
-                let offset: u8 = {
-                    if address_bit % 2 != 0 {
-                        4
-                    } else {
-                        0
-                    }
-                };
-
-                // Encode MSB first. Least significant bits are placed at the most significant
-                // byte.
-                let byte_position = 3 - (address_bit >> 1) as usize;
-
-                if addr & (1 << address_bit) != 0 {
-                    encoded_data[byte_position] |= 1 << offset;
+                if (data.len() * 4) > (encoded_data.len() - 4) {
+                    return Err(Error::Bounds);
                 }
-            }
 
-            // Encode the data into the remaining bytes.
-            for byte_index in 0..data.len() {
-                let byte = data[byte_index];
-                for bit in 0..8 {
+                // Encode the address into the first 4 bytes.
+                for address_bit in 0..8 {
                     let offset: u8 = {
-                        if bit % 2 != 0 {
+                        if address_bit % 2 != 0 {
                             4
                         } else {
                             0
                         }
                     };
 
-                    // Encode MSB first. Least significant bits are placed at the most
-                    // significant byte.
-                    let byte_position = 3 - (bit >> 1) as usize;
+                    // Encode MSB first. Least significant bits are placed at the most significant
+                    // byte.
+                    let byte_position = 3 - (address_bit >> 1) as usize;
 
-                    if byte & (1 << bit) != 0 {
-                        encoded_data
-                            [(byte_index + 1) * 4 + byte_position] |=
-                            1 << offset;
+                    if addr & (1 << address_bit) != 0 {
+                        encoded_data[byte_position] |= 1 << offset;
                     }
                 }
-            }
 
-            let (encoded_address, encoded_payload) = {
-                let end_index = (1 + data.len()) * 4;
-                (encoded_data[0], &encoded_data[1..end_index])
-            };
+                // Encode the data into the remaining bytes.
+                for byte_index in 0..data.len() {
+                    let byte = data[byte_index];
+                    for bit in 0..8 {
+                        let offset: u8 = {
+                            if bit % 2 != 0 {
+                                4
+                            } else {
+                                0
+                            }
+                        };
 
-            self.qspi.write(encoded_address, encoded_payload)?;
+                        // Encode MSB first. Least significant bits are placed at the most
+                        // significant byte.
+                        let byte_position = 3 - (bit >> 1) as usize;
 
-            Ok(())
-        }
-        ad9959::Mode::FourBitSerial => {
-            if self.streaming {
-                Err(Error::InvalidState)
-            } else {
-                self.qspi.write(addr, data)?;
+                        if byte & (1 << bit) != 0 {
+                            encoded_data
+                                [(byte_index + 1) * 4 + byte_position] |=
+                                1 << offset;
+                        }
+                    }
+                }
+
+                let (encoded_address, encoded_payload) = {
+                    let end_index = (1 + data.len()) * 4;
+                    (encoded_data[0], &encoded_data[1..end_index])
+                };
+
+                self.qspi.write(encoded_address, encoded_payload)?;
+
                 Ok(())
             }
+            ad9959::Mode::FourBitSerial => {
+                if self.streaming {
+                    Err(Error::InvalidState)
+                } else {
+                    self.qspi.write(addr, data)?;
+                    Ok(())
+                }
+            }
+            _ => Err(Error::InvalidState),
         }
-        _ => Err(Error::InvalidState),
-    }
-}
-
-fn read(&mut self, addr: u8, dest: &mut [u8]) -> Result<(), Error> {
-    if (addr & 0x80) != 0 {
-        return Err(Error::InvalidAddress);
     }
 
-    // This implementation only supports operation (read) in four-bit-serial mode.
-    if self.mode != ad9959::Mode::FourBitSerial {
-        return Err(Error::InvalidState);
+    fn read(&mut self, addr: u8, dest: &mut [u8]) -> Result<(), Error> {
+        if (addr & 0x80) != 0 {
+            return Err(Error::InvalidAddress);
+        }
+
+        // This implementation only supports operation (read) in four-bit-serial mode.
+        if self.mode != ad9959::Mode::FourBitSerial {
+            return Err(Error::InvalidState);
+        }
+
+        self.qspi.read(0x80 | addr, dest)?;
+
+        Ok(())
     }
-
-    self.qspi.read(0x80 | addr, dest)?;
-
-    Ok(())
-}
 }
 
 /// A structure containing implementation for Pounder hardware.
 pub struct PounderDevices {
-mcp23017: mcp23017::MCP23017<hal::i2c::I2c<hal::stm32::I2C1>>,
-attenuator_spi: hal::spi::Spi<hal::stm32::SPI1, hal::spi::Enabled, u8>,
-pwr0: AdcChannel<
-    'static,
-    hal::stm32::ADC1,
-    hal::gpio::gpiof::PF11<hal::gpio::Analog>,
->,
-pwr1: AdcChannel<
-    'static,
-    hal::stm32::ADC2,
-    hal::gpio::gpiof::PF14<hal::gpio::Analog>,
->,
-aux_adc0: AdcChannel<
-    'static,
-    hal::stm32::ADC3,
-    hal::gpio::gpiof::PF3<hal::gpio::Analog>,
->,
-aux_adc1: AdcChannel<
-    'static,
-    hal::stm32::ADC3,
-    hal::gpio::gpiof::PF4<hal::gpio::Analog>,
->,
-}
-
-impl PounderDevices {
-/// Construct and initialize pounder-specific hardware.
-///
-/// Args:
-/// * `attenuator_spi` - A SPI interface to control digital attenuators.
-/// * `pwr0` - The ADC channel to measure the IN0 input power.
-/// * `pwr1` - The ADC channel to measure the IN1 input power.
-/// * `aux_adc0` - The ADC channel to measure the ADC0 auxiliary input.
-/// * `aux_adc1` - The ADC channel to measure the ADC1 auxiliary input.
-pub fn new(
     mcp23017: mcp23017::MCP23017<hal::i2c::I2c<hal::stm32::I2C1>>,
     attenuator_spi: hal::spi::Spi<hal::stm32::SPI1, hal::spi::Enabled, u8>,
     pwr0: AdcChannel<
@@ -332,22 +298,56 @@ pub fn new(
         hal::stm32::ADC3,
         hal::gpio::gpiof::PF4<hal::gpio::Analog>,
     >,
-) -> Result<Self, Error> {
-    let mut devices = Self {
-        mcp23017,
-        attenuator_spi,
-        pwr0,
-        pwr1,
-        aux_adc0,
-        aux_adc1,
-    };
+}
 
-    // Configure power-on-default state for pounder. All LEDs are off, on-board oscillator
-    // selected and enabled, attenuators out of reset. Note that testing indicates the
-    // output state needs to be set first to properly update the output registers.
-    devices
-        .mcp23017
-        .all_pin_mode(mcp23017::PinMode::OUTPUT)
+impl PounderDevices {
+    /// Construct and initialize pounder-specific hardware.
+    ///
+    /// Args:
+    /// * `attenuator_spi` - A SPI interface to control digital attenuators.
+    /// * `pwr0` - The ADC channel to measure the IN0 input power.
+    /// * `pwr1` - The ADC channel to measure the IN1 input power.
+    /// * `aux_adc0` - The ADC channel to measure the ADC0 auxiliary input.
+    /// * `aux_adc1` - The ADC channel to measure the ADC1 auxiliary input.
+    pub fn new(
+        mcp23017: mcp23017::MCP23017<hal::i2c::I2c<hal::stm32::I2C1>>,
+        attenuator_spi: hal::spi::Spi<hal::stm32::SPI1, hal::spi::Enabled, u8>,
+        pwr0: AdcChannel<
+            'static,
+            hal::stm32::ADC1,
+            hal::gpio::gpiof::PF11<hal::gpio::Analog>,
+        >,
+        pwr1: AdcChannel<
+            'static,
+            hal::stm32::ADC2,
+            hal::gpio::gpiof::PF14<hal::gpio::Analog>,
+        >,
+        aux_adc0: AdcChannel<
+            'static,
+            hal::stm32::ADC3,
+            hal::gpio::gpiof::PF3<hal::gpio::Analog>,
+        >,
+        aux_adc1: AdcChannel<
+            'static,
+            hal::stm32::ADC3,
+            hal::gpio::gpiof::PF4<hal::gpio::Analog>,
+        >,
+    ) -> Result<Self, Error> {
+        let mut devices = Self {
+            mcp23017,
+            attenuator_spi,
+            pwr0,
+            pwr1,
+            aux_adc0,
+            aux_adc1,
+        };
+
+        // Configure power-on-default state for pounder. All LEDs are off, on-board oscillator
+        // selected and enabled, attenuators out of reset. Note that testing indicates the
+        // output state needs to be set first to properly update the output registers.
+        devices
+            .mcp23017
+            .all_pin_mode(mcp23017::PinMode::OUTPUT)
             .map_err(|_| Error::I2c)?;
         devices
             .mcp23017

--- a/src/hardware/pounder/mod.rs
+++ b/src/hardware/pounder/mod.rs
@@ -360,8 +360,8 @@ impl PounderDevices {
 
     pub fn sample_aux_adc(&mut self, channel: Channel) -> Result<f32, Error> {
         let adc_scale = match channel {
-            Channel::In0 => self.aux_adc0.read(),
-            Channel::In1 => self.aux_adc1.read(),
+            Channel::In0 => self.aux_adc0.read().unwrap(),
+            Channel::In1 => self.aux_adc1.read().unwrap(),
             _ => return Err(Error::InvalidChannel),
         };
 
@@ -428,8 +428,8 @@ impl rf_power::PowerMeasurementInterface for PounderDevices {
     /// The sampled voltage of the specified channel.
     fn sample_converter(&mut self, channel: Channel) -> Result<f32, Error> {
         let adc_scale = match channel {
-            Channel::In0 => self.pwr0.read(),
-            Channel::In1 => self.pwr1.read(),
+            Channel::In0 => self.pwr0.read().unwrap(),
+            Channel::In1 => self.pwr1.read().unwrap(),
             _ => return Err(Error::InvalidChannel),
         };
 

--- a/src/hardware/pounder/mod.rs
+++ b/src/hardware/pounder/mod.rs
@@ -1,5 +1,6 @@
 use super::hal;
-use embedded_hal::{adc::OneShot, blocking::spi::Transfer};
+use crate::hardware::shared_adc::AdcChannel;
+use embedded_hal::blocking::spi::Transfer;
 use serde::{Deserialize, Serialize};
 
 pub mod attenuators;
@@ -274,13 +275,26 @@ impl ad9959::Interface for QspiInterface {
 pub struct PounderDevices {
     mcp23017: mcp23017::MCP23017<hal::i2c::I2c<hal::stm32::I2C1>>,
     attenuator_spi: hal::spi::Spi<hal::stm32::SPI1, hal::spi::Enabled, u8>,
-    adc1: hal::adc::Adc<hal::stm32::ADC1, hal::adc::Enabled>,
-    adc2: hal::adc::Adc<hal::stm32::ADC2, hal::adc::Enabled>,
-    adc3: hal::adc::Adc<hal::stm32::ADC3, hal::adc::Enabled>,
-    pwr0: hal::gpio::gpiof::PF11<hal::gpio::Analog>,
-    pwr1: hal::gpio::gpiof::PF14<hal::gpio::Analog>,
-    aux_adc0: hal::gpio::gpiof::PF3<hal::gpio::Analog>,
-    aux_adc1: hal::gpio::gpiof::PF4<hal::gpio::Analog>,
+    pwr0: AdcChannel<
+        'static,
+        hal::stm32::ADC1,
+        hal::gpio::gpiof::PF11<hal::gpio::Analog>,
+    >,
+    pwr1: AdcChannel<
+        'static,
+        hal::stm32::ADC2,
+        hal::gpio::gpiof::PF14<hal::gpio::Analog>,
+    >,
+    aux_adc0: AdcChannel<
+        'static,
+        hal::stm32::ADC3,
+        hal::gpio::gpiof::PF3<hal::gpio::Analog>,
+    >,
+    aux_adc1: AdcChannel<
+        'static,
+        hal::stm32::ADC3,
+        hal::gpio::gpiof::PF4<hal::gpio::Analog>,
+    >,
 }
 
 impl PounderDevices {
@@ -288,34 +302,41 @@ impl PounderDevices {
     ///
     /// Args:
     /// * `attenuator_spi` - A SPI interface to control digital attenuators.
-    /// * `adcs` - The ADC1, ADC2, ADC3 peripherals.
-    /// * `adc_pins` - The ADC input channel pins for the RF power measurement on IN0/IN1 and AUX
-    ///     ADC0 and AUX ADC1.
+    /// * `pwr0` - The ADC channel to measure the IN0 input power.
+    /// * `pwr1` - The ADC channel to measure the IN1 input power.
+    /// * `aux_adc0` - The ADC channel to measure the ADC0 auxiliary input.
+    /// * `aux_adc1` - The ADC channel to measure the ADC1 auxiliary input.
     pub fn new(
         mcp23017: mcp23017::MCP23017<hal::i2c::I2c<hal::stm32::I2C1>>,
         attenuator_spi: hal::spi::Spi<hal::stm32::SPI1, hal::spi::Enabled, u8>,
-        adcs: (
-            hal::adc::Adc<hal::stm32::ADC1, hal::adc::Enabled>,
-            hal::adc::Adc<hal::stm32::ADC2, hal::adc::Enabled>,
-            hal::adc::Adc<hal::stm32::ADC3, hal::adc::Enabled>,
-        ),
-        adc_pins: (
+        pwr0: AdcChannel<
+            'static,
+            hal::stm32::ADC1,
             hal::gpio::gpiof::PF11<hal::gpio::Analog>,
+        >,
+        pwr1: AdcChannel<
+            'static,
+            hal::stm32::ADC2,
             hal::gpio::gpiof::PF14<hal::gpio::Analog>,
+        >,
+        aux_adc0: AdcChannel<
+            'static,
+            hal::stm32::ADC3,
             hal::gpio::gpiof::PF3<hal::gpio::Analog>,
+        >,
+        aux_adc1: AdcChannel<
+            'static,
+            hal::stm32::ADC3,
             hal::gpio::gpiof::PF4<hal::gpio::Analog>,
-        ),
+        >,
     ) -> Result<Self, Error> {
         let mut devices = Self {
             mcp23017,
             attenuator_spi,
-            adc1: adcs.0,
-            adc2: adcs.1,
-            adc3: adcs.2,
-            pwr0: adc_pins.0,
-            pwr1: adc_pins.1,
-            aux_adc0: adc_pins.2,
-            aux_adc1: adc_pins.3,
+            pwr0,
+            pwr1,
+            aux_adc0,
+            aux_adc1,
         };
 
         // Configure power-on-default state for pounder. All LEDs are off, on-board oscillator
@@ -339,20 +360,8 @@ impl PounderDevices {
 
     pub fn sample_aux_adc(&mut self, channel: Channel) -> Result<f32, Error> {
         let adc_scale = match channel {
-            Channel::In0 => {
-                let adc_reading: u32 = self
-                    .adc3
-                    .read(&mut self.aux_adc0)
-                    .map_err(|_| Error::Adc)?;
-                adc_reading as f32 / self.adc3.slope() as f32
-            }
-            Channel::In1 => {
-                let adc_reading: u32 = self
-                    .adc3
-                    .read(&mut self.aux_adc1)
-                    .map_err(|_| Error::Adc)?;
-                adc_reading as f32 / self.adc3.slope() as f32
-            }
+            Channel::In0 => self.aux_adc0.read(),
+            Channel::In1 => self.aux_adc1.read(),
             _ => return Err(Error::InvalidChannel),
         };
 
@@ -419,16 +428,8 @@ impl rf_power::PowerMeasurementInterface for PounderDevices {
     /// The sampled voltage of the specified channel.
     fn sample_converter(&mut self, channel: Channel) -> Result<f32, Error> {
         let adc_scale = match channel {
-            Channel::In0 => {
-                let adc_reading: u32 =
-                    self.adc1.read(&mut self.pwr0).map_err(|_| Error::Adc)?;
-                adc_reading as f32 / self.adc1.slope() as f32
-            }
-            Channel::In1 => {
-                let adc_reading: u32 =
-                    self.adc2.read(&mut self.pwr1).map_err(|_| Error::Adc)?;
-                adc_reading as f32 / self.adc2.slope() as f32
-            }
+            Channel::In0 => self.pwr0.read(),
+            Channel::In1 => self.pwr1.read(),
             _ => return Err(Error::InvalidChannel),
         };
 

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -801,10 +801,10 @@ pub fn setup(
             )
         };
 
-        let pwr0 = adc1.create_channel(gpiof.pf11.into_analog()).unwrap();
-        let pwr1 = adc2.create_channel(gpiof.pf14.into_analog()).unwrap();
-        let aux_adc0 = adc3.create_channel(gpiof.pf3.into_analog()).unwrap();
-        let aux_adc1 = adc3.create_channel(gpiof.pf4.into_analog()).unwrap();
+        let pwr0 = adc1.create_channel(gpiof.pf11.into_analog());
+        let pwr1 = adc2.create_channel(gpiof.pf14.into_analog());
+        let aux_adc0 = adc3.create_channel(gpiof.pf3.into_analog());
+        let aux_adc1 = adc3.create_channel(gpiof.pf4.into_analog());
 
         let pounder_devices = pounder::PounderDevices::new(
             io_expander,

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -14,7 +14,7 @@ use smoltcp_nal::smoltcp;
 
 use super::{
     adc, afe, dac, design_parameters, eeprom, input_stamper::InputStamper,
-    pounder, pounder::dds_output::DdsOutput, timers, DigitalInput0,
+    pounder, pounder::dds_output::DdsOutput, shared_adc, timers, DigitalInput0,
     DigitalInput1, EthernetPhy, NetworkStack, SystemTimer, Systick, AFE0, AFE1,
 };
 
@@ -722,6 +722,36 @@ pub fn setup(
     fp_led_2.set_low();
     fp_led_3.set_low();
 
+    let (adc1, adc2, adc3) = {
+        let (mut adc1, mut adc2) = hal::adc::adc12(
+            device.ADC1,
+            device.ADC2,
+            &mut delay,
+            ccdr.peripheral.ADC12,
+            &ccdr.clocks,
+        );
+        let mut adc3 = hal::adc::Adc::adc3(
+            device.ADC3,
+            &mut delay,
+            ccdr.peripheral.ADC3,
+            &ccdr.clocks,
+        );
+        adc1.set_sample_time(hal::adc::AdcSampleTime::T_810);
+        adc1.set_resolution(hal::adc::Resolution::SIXTEENBIT);
+        adc2.set_sample_time(hal::adc::AdcSampleTime::T_810);
+        adc2.set_resolution(hal::adc::Resolution::SIXTEENBIT);
+        adc3.set_sample_time(hal::adc::AdcSampleTime::T_810);
+        adc3.set_resolution(hal::adc::Resolution::SIXTEENBIT);
+
+        hal::adc::Temperature::new().enable(&adc3);
+
+        (adc1.enable(), adc2.enable(), adc3.enable())
+    };
+
+    let adc1 = shared_adc::new_shared_adc!(hal::stm32::ADC1 = adc1).unwrap();
+    let adc2 = shared_adc::new_shared_adc!(hal::stm32::ADC2 = adc2).unwrap();
+    let adc3 = shared_adc::new_shared_adc!(hal::stm32::ADC3 = adc3).unwrap();
+
     // Measure the Pounder PGOOD output to detect if pounder is present on Stabilizer.
     let pounder_pgood = gpiob.pb13.into_pull_down_input();
     delay.delay_ms(2u8);
@@ -761,40 +791,18 @@ pub fn setup(
             )
         };
 
-        let (adc1, adc2, adc3) = {
-            let (mut adc1, mut adc2) = hal::adc::adc12(
-                device.ADC1,
-                device.ADC2,
-                &mut delay,
-                ccdr.peripheral.ADC12,
-                &ccdr.clocks,
-            );
-            let mut adc3 = hal::adc::Adc::adc3(
-                device.ADC3,
-                &mut delay,
-                ccdr.peripheral.ADC3,
-                &ccdr.clocks,
-            );
-            adc1.set_sample_time(hal::adc::AdcSampleTime::T_810);
-            adc1.set_resolution(hal::adc::Resolution::SIXTEENBIT);
-            adc2.set_sample_time(hal::adc::AdcSampleTime::T_810);
-            adc2.set_resolution(hal::adc::Resolution::SIXTEENBIT);
-            adc3.set_sample_time(hal::adc::AdcSampleTime::T_810);
-            adc3.set_resolution(hal::adc::Resolution::SIXTEENBIT);
-
-            (adc1.enable(), adc2.enable(), adc3.enable())
-        };
-
-        let pwr0 = gpiof.pf11.into_analog();
-        let pwr1 = gpiof.pf14.into_analog();
-        let aux_adc0 = gpiof.pf3.into_analog();
-        let aux_adc1 = gpiof.pf4.into_analog();
+        let pwr0 = adc1.create_channel(gpiof.pf11.into_analog()).unwrap();
+        let pwr1 = adc2.create_channel(gpiof.pf14.into_analog()).unwrap();
+        let aux_adc0 = adc3.create_channel(gpiof.pf3.into_analog()).unwrap();
+        let aux_adc1 = adc3.create_channel(gpiof.pf4.into_analog()).unwrap();
 
         let pounder_devices = pounder::PounderDevices::new(
             io_expander,
             spi,
-            (adc1, adc2, adc3),
-            (pwr0, pwr1, aux_adc0, aux_adc1),
+            pwr0,
+            pwr1,
+            aux_adc0,
+            aux_adc1,
         )
         .unwrap();
 

--- a/src/hardware/shared_adc.rs
+++ b/src/hardware/shared_adc.rs
@@ -1,0 +1,80 @@
+use embedded_hal::adc::{Channel, OneShot};
+use stm32h7xx_hal as hal;
+
+#[derive(Debug, Copy, Clone)]
+pub enum AdcError {
+    Allocated,
+}
+
+pub struct AdcChannel<'a, Adc, PIN> {
+    pin: PIN,
+    slope: f32,
+    adc: &'a cortex_m::interrupt::Mutex<
+        core::cell::RefCell<hal::adc::Adc<Adc, hal::adc::Enabled>>,
+    >,
+}
+
+impl<'a, Adc, PIN> AdcChannel<'a, Adc, PIN>
+where
+    PIN: Channel<Adc, ID = u8>,
+    hal::adc::Adc<Adc, hal::adc::Enabled>: OneShot<Adc, u32, PIN>,
+    <hal::adc::Adc<Adc, hal::adc::Enabled> as OneShot<Adc, u32, PIN>>::Error:
+        core::fmt::Debug,
+{
+    pub fn read(&mut self) -> f32 {
+        cortex_m::interrupt::free(|cs| {
+            let adc = self.adc.borrow(cs);
+            adc.borrow_mut().read(&mut self.pin).unwrap() as f32 / self.slope
+        })
+    }
+}
+
+pub struct SharedAdc<Adc> {
+    mutex: cortex_m::interrupt::Mutex<
+        core::cell::RefCell<hal::adc::Adc<Adc, hal::adc::Enabled>>,
+    >,
+    allocated_channels: core::cell::RefCell<[bool; 15]>,
+    slope: f32,
+}
+
+impl<Adc> SharedAdc<Adc> {
+    pub fn new(slope: f32, adc: hal::adc::Adc<Adc, hal::adc::Enabled>) -> Self {
+        Self {
+            slope,
+            mutex: cortex_m::interrupt::Mutex::new(core::cell::RefCell::new(
+                adc,
+            )),
+            allocated_channels: core::cell::RefCell::new([false; 15]),
+        }
+    }
+
+    pub fn create_channel<PIN: Channel<Adc, ID = u8>>(
+        &self,
+        pin: PIN,
+    ) -> Result<AdcChannel<'_, Adc, PIN>, AdcError> {
+        let mut channels = self.allocated_channels.borrow_mut();
+        if channels[PIN::channel() as usize] {
+            return Err(AdcError::Allocated);
+        }
+
+        channels[PIN::channel() as usize] = true;
+
+        Ok(AdcChannel {
+            pin,
+            slope: self.slope,
+            adc: &self.mutex,
+        })
+    }
+}
+
+macro_rules! new_shared_adc {
+    ($adc_type:ty = $adc:expr) => {{
+        let m: Option<&'static mut _> = cortex_m::singleton!(
+            : $crate::hardware::shared_adc::SharedAdc<$adc_type> = $crate::hardware::shared_adc::SharedAdc::new($adc.slope() as f32, $adc)
+        );
+
+        m
+    }};
+}
+
+pub(crate) use new_shared_adc;

--- a/src/hardware/shared_adc.rs
+++ b/src/hardware/shared_adc.rs
@@ -33,7 +33,7 @@ pub struct SharedAdc<Adc> {
     mutex: cortex_m::interrupt::Mutex<
         core::cell::RefCell<hal::adc::Adc<Adc, hal::adc::Enabled>>,
     >,
-    allocated_channels: core::cell::RefCell<[bool; 15]>,
+    allocated_channels: core::cell::RefCell<[bool; 20]>,
     slope: f32,
 }
 
@@ -44,7 +44,7 @@ impl<Adc> SharedAdc<Adc> {
             mutex: cortex_m::interrupt::Mutex::new(core::cell::RefCell::new(
                 adc,
             )),
-            allocated_channels: core::cell::RefCell::new([false; 15]),
+            allocated_channels: core::cell::RefCell::new([false; 20]),
         }
     }
 


### PR DESCRIPTION
This PR presents a proof-of-concept for using an ADC with many different channels that are needed by different drivers.

The implementation mirrors that of `shared-bus`. 

This builds on #572 