### PR TITLE
use refactored mcp230xx

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,11 +1,11 @@
 block_labels = [ "S-blocked" ]
 delete_merged_branches = true
 timeout_sec = 1200
-# keep MSRV in sync in ci.yaml, bors.toml, and setup.md
+# keep MSRV in sync in ci.yaml, bors.toml, Cargo.toml, and setup.md
 status = [
   "style",
   "compile (stable)",
-  "compile (1.59.0)",
+  "compile (1.62.0)",
   "doc",
   "HITL Run Status"
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     strategy:
       matrix:
-        # keep MSRV in sync in ci.yaml, bors.toml, and setup.md
-        toolchain: [stable, '1.59.0']
+        # keep MSRV in sync in ci.yaml, bors.toml, Cargo.toml, and setup.md
+        toolchain: [stable, '1.62.0']
         features: ['']
         include:
           - toolchain: beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Temperature sensor measurement for Pounder and Stabilizer's CPU has been added [#575](https://github.com/quartiq/stabilizer/pull/575)
 
 ### Removed
+
 ### Changed
 
-* Minimum supported Rust version bumped to 1.59
+* Minimum supported Rust version bumped to 1.62
 
 ### Fixed
+
 * Fixed panics when using a batch size of 1 ([#540](https://github.com/quartiq/stabilizer/issues/540))
 
 ## [v0.6.0] - 2022-02-11

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 [[package]]
 name = "mcp230xx"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/mcp230xx.git?branch=refactor#9d8f8f6cf6916d3887034d54aa6a83bb4f010798"
+source = "git+https://github.com/quartiq/mcp230xx.git?branch=refactor#18c57dbda75eed9e1d2422c78bde59db32190bfe"
 dependencies = [
  "bit_field",
  "embedded-hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,8 +431,9 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "mcp230xx"
-version = "0.0.0"
-source = "git+https://github.com/quartiq/mcp230xx.git?branch=refactor#bf61eea086d61b18e29d8abc67838b4666242ab7"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf09e3689e2dcf7e563015ab094f224be2997035ea8e00e83ef97ed2ee4fe729"
 dependencies = [
  "bit_field",
  "embedded-hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,11 +423,12 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 [[package]]
 name = "mcp230xx"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/mcp230xx.git?branch=refactor#7855784c642f9599e328809d3acd85731e52e1e9"
+source = "git+https://github.com/quartiq/mcp230xx.git?branch=refactor#71806afe39efd6a9be67defec3e79530d20b2e19"
 dependencies = [
  "bit_field",
  "embedded-hal",
  "num_enum",
+ "paste",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,9 +421,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
-name = "mcp23017"
-version = "1.0.0"
-source = "git+https://github.com/quartiq/mcp23017.git?branch=refactor#0ba8b1d3cc6d171b8f3c5b7a547563ec400e5b8c"
+name = "mcp230xx"
+version = "0.1.0"
+source = "git+https://github.com/quartiq/mcp230xx.git?branch=refactor#7855784c642f9599e328809d3acd85731e52e1e9"
 dependencies = [
  "bit_field",
  "embedded-hal",
@@ -603,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
+checksum = "9423e2b32f7a043629287a536f21951e8c6a82482d0acb1eeebfc90bc2225b22"
 
 [[package]]
 name = "proc-macro-error"
@@ -893,7 +893,7 @@ dependencies = [
  "heapless",
  "idsp",
  "log",
- "mcp23017",
+ "mcp230xx",
  "miniconf",
  "minimq",
  "mono-clock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,8 +431,8 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "mcp230xx"
-version = "0.1.0"
-source = "git+https://github.com/quartiq/mcp230xx.git?branch=refactor#18c57dbda75eed9e1d2422c78bde59db32190bfe"
+version = "0.0.0"
+source = "git+https://github.com/quartiq/mcp230xx.git?branch=refactor#d828e71fc6ff272a8beb243bab666919d7b4b03b"
 dependencies = [
  "bit_field",
  "embedded-hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,7 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 [[package]]
 name = "mcp230xx"
 version = "0.0.0"
-source = "git+https://github.com/quartiq/mcp230xx.git?branch=refactor#d828e71fc6ff272a8beb243bab666919d7b4b03b"
+source = "git+https://github.com/quartiq/mcp230xx.git?branch=refactor#bf61eea086d61b18e29d8abc67838b4666242ab7"
 dependencies = [
  "bit_field",
  "embedded-hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 [[package]]
 name = "mcp230xx"
 version = "0.1.0"
-source = "git+https://github.com/quartiq/mcp230xx.git?branch=refactor#71806afe39efd6a9be67defec3e79530d20b2e19"
+source = "git+https://github.com/quartiq/mcp230xx.git?branch=refactor#9d8f8f6cf6916d3887034d54aa6a83bb4f010798"
 dependencies = [
  "bit_field",
  "embedded-hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,10 +423,11 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 [[package]]
 name = "mcp23017"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c32fd6627e73f1cfa95c00ddcdcb5a6a6ddbd10b308d08588a502c018b6e12c"
+source = "git+https://github.com/quartiq/mcp23017.git?branch=refactor#9fdda4b8e02f493619eb133be7213f1ecac801bd"
 dependencies = [
+ "bit_field",
  "embedded-hal",
+ "num_enum",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 [[package]]
 name = "mcp23017"
 version = "1.0.0"
-source = "git+https://github.com/quartiq/mcp23017.git?branch=refactor#9fdda4b8e02f493619eb133be7213f1ecac801bd"
+source = "git+https://github.com/quartiq/mcp23017.git?branch=refactor#0ba8b1d3cc6d171b8f3c5b7a547563ec400e5b8c"
 dependencies = [
  "bit_field",
  "embedded-hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,16 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c79a6321a1197d7730510c7e3f6cb80432dfefecb32426de8cea0aa19b4bb8d7"
 dependencies = [
- "enum-iterator-derive",
+ "enum-iterator-derive 0.6.0",
+]
+
+[[package]]
+name = "enum-iterator"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a0ac4aeb3a18f92eaf09c6bb9b3ac30ff61ca95514fc58cbead1c9a6bf5401"
+dependencies = [
+ "enum-iterator-derive 1.0.2",
 ]
 
 [[package]]
@@ -280,6 +289,17 @@ name = "enum-iterator-derive"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e94aa31f7c0dc764f57896dc615ddd76fc13b0d5dca7eb6cc5e018a5a09ec06"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13f1e69590421890f90448c3cd5f554746a31adc6dc0dac406ec6901db8dc25"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -471,7 +491,7 @@ dependencies = [
  "bit_field",
  "embedded-nal",
  "embedded-time",
- "enum-iterator",
+ "enum-iterator 0.6.0",
  "heapless",
  "smlang",
 ]
@@ -900,6 +920,7 @@ dependencies = [
  "cortex-m-rt",
  "cortex-m-rtic",
  "embedded-hal",
+ "enum-iterator 1.1.3",
  "fugit",
  "heapless",
  "idsp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ mono-clock = "0.1"
 spin = { version = "0.9", default-features = false, features = ["spin_mutex"]}
 shared-bus = "0.2"
 lm75 = "0.2"
+enum-iterator = "1.1.3"
 
 [dependencies.stm32h7xx-hal]
 features = ["stm32h743v", "rt", "ethernet", "xspi"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ ad9959 = { path = "ad9959", version = "0.1.0" }
 miniconf = "0.5"
 smoltcp-nal = { version = "0.2", features = ["shared-stack"] }
 serde-json-core = "0.4"
-mcp230xx = { git = "https://github.com/quartiq/mcp230xx.git", branch = "refactor" }
+mcp230xx = "0.1"
 mutex-trait = "0.2"
 minimq = "0.5.3"
 fugit = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ ad9959 = { path = "ad9959", version = "0.1.0" }
 miniconf = "0.5"
 smoltcp-nal = { version = "0.2", features = ["shared-stack"] }
 serde-json-core = "0.4"
-mcp23017 = { git = "https://github.com/quartiq/mcp23017.git", branch = "refactor" }
+mcp230xx = { git = "https://github.com/quartiq/mcp230xx.git", branch = "refactor" }
 mutex-trait = "0.2"
 minimq = "0.5.3"
 fugit = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ ad9959 = { path = "ad9959", version = "0.1.0" }
 miniconf = "0.5"
 smoltcp-nal = { version = "0.2", features = ["shared-stack"] }
 serde-json-core = "0.4"
-mcp23017 = "1.0"
+mcp23017 = { git = "https://github.com/quartiq/mcp23017.git", branch = "refactor" }
 mutex-trait = "0.2"
 minimq = "0.5.3"
 fugit = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ repository = "https://github.com/quartiq/stabilizer"
 readme = "README.md"
 documentation = "https://docs.rs/stabilizer/"
 edition = "2021"
-rust-version = "1.59"
+# keep MSRV in sync in ci.yaml, bors.toml, Cargo.toml, and setup.md
+rust-version = "1.62"
 exclude = [
 	".gitignore",
 	"doc/",

--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -68,22 +68,22 @@ docker run -p 1883:1883 --name mosquitto -v ${pwd}/mosquitto.conf:/mosquitto/con
 ## Building
 
 1. Get and install [rustup](https://rustup.rs/) and use it to install a current stable Rust toolchain.
-    The minimum supported Rust version (MSRV) is 1.59.0 (2021 edition).
+    The minimum supported Rust version (MSRV) is 1.62.0 (2021 edition).
 1. Install target support
     ```bash
     rustup target add thumbv7em-none-eabihf
     ```
-1. Install [cargo-binutils](https://github.com/rust-embedded/cargo-binutils/)
+2. Install [cargo-binutils](https://github.com/rust-embedded/cargo-binutils/)
     ```bash
     cargo install cargo-binutils
     rustup component add llvm-tools-preview
     ```
-1. Clone or download the firmware
+3. Clone or download the firmware
     ```bash
     git clone https://github.com/quartiq/stabilizer
     cd stabilizer
     ```
-1. Build firmware specifying the MQTT broker IP. Replace `10.34.16.10` by the
+4. Build firmware specifying the MQTT broker IP. Replace `10.34.16.10` by the
     stable and reachable broker IPv4 address determined above.
     ```bash
     # Bash
@@ -93,7 +93,7 @@ docker run -p 1883:1883 --name mosquitto -v ${pwd}/mosquitto.conf:/mosquitto/con
     # Note: This sets the broker for all future builds as well.
     $env:BROKER='10.34.16.10'; cargo build --release
     ```
-1. Extract the application binary (substitute `dual-iir` below with the desired application name)
+5. Extract the application binary (substitute `dual-iir` below with the desired application name)
     ```bash
     # Bash
     BROKER="10.34.16.10" cargo objcopy --release --bin dual-iir -- -O binary dual-iir.bin

--- a/src/hardware/pounder/mod.rs
+++ b/src/hardware/pounder/mod.rs
@@ -1,3 +1,5 @@
+use self::attenuators::AttenuatorInterface;
+
 use super::hal;
 use crate::hardware::shared_adc::AdcChannel;
 use embedded_hal::blocking::spi::Transfer;
@@ -379,11 +381,11 @@ impl PounderDevices {
         // selected and enabled, attenuators out of reset. Note that testing indicates the
         // output state needs to be set first to properly update the output registers.
         for (pin, level) in [
-            (GpioPin::AttLe0, mcp230xx::Level::High),
-            (GpioPin::AttLe1, mcp230xx::Level::High),
-            (GpioPin::AttLe2, mcp230xx::Level::High),
-            (GpioPin::AttLe3, mcp230xx::Level::High),
-            (GpioPin::AttRstN, mcp230xx::Level::High),
+            (GpioPin::AttLe1, mcp230xx::Level::Low),
+            (GpioPin::AttLe2, mcp230xx::Level::Low),
+            (GpioPin::AttLe3, mcp230xx::Level::Low),
+            (GpioPin::AttLe0, mcp230xx::Level::Low),
+            (GpioPin::AttRstN, mcp230xx::Level::Low),
             (GpioPin::ExtClkSel, mcp230xx::Level::Low),
             (GpioPin::OscEnN, mcp230xx::Level::Low),
             (GpioPin::Led4Green, mcp230xx::Level::Low),
@@ -404,7 +406,7 @@ impl PounderDevices {
                 .set_direction(pin.into(), mcp230xx::Direction::Output)
                 .map_err(|_| Error::I2c)?;
         }
-
+        devices.reset_attenuators();
         Ok(devices)
     }
 
@@ -459,9 +461,9 @@ impl attenuators::AttenuatorInterface for PounderDevices {
     /// Args:
     /// * `channel` - The attenuator channel to latch.
     fn latch_attenuator(&mut self, channel: Channel) -> Result<(), Error> {
-        self.set_gpio_pin(channel.into(), mcp230xx::Level::Low)?;
         // Rising edge sensitive
-        self.set_gpio_pin(channel.into(), mcp230xx::Level::High)
+        self.set_gpio_pin(channel.into(), mcp230xx::Level::High)?;
+        self.set_gpio_pin(channel.into(), mcp230xx::Level::Low)
     }
 
     /// Read the raw attenuation codes stored in the attenuator shift registers.

--- a/src/hardware/pounder/mod.rs
+++ b/src/hardware/pounder/mod.rs
@@ -30,7 +30,7 @@ pub enum GpioPin {
     ExtClkSel,
 }
 
-impl From<GpioPin> for mcp230xx::Mcp23017Pin {
+impl From<GpioPin> for mcp230xx::Mcp23017 {
     fn from(x: GpioPin) -> Self {
         match x {
             GpioPin::Led4Green => Self::A0,

--- a/src/hardware/pounder/mod.rs
+++ b/src/hardware/pounder/mod.rs
@@ -447,8 +447,9 @@ impl attenuators::AttenuatorInterface for PounderDevices {
     /// * `channel` - The attenuator channel to latch.
     fn latch_attenuator(&mut self, channel: Channel) -> Result<(), Error> {
         // Rising edge sensitive
-        self.set_gpio_pin(channel.into(), mcp230xx::Level::High)?;
-        self.set_gpio_pin(channel.into(), mcp230xx::Level::Low)
+        // Be robust against initial state: drive low, then high (contrary to the datasheet figure).
+        self.set_gpio_pin(channel.into(), mcp230xx::Level::Low)?;
+        self.set_gpio_pin(channel.into(), mcp230xx::Level::High)
     }
 
     /// Read the raw attenuation codes stored in the attenuator shift registers.

--- a/src/hardware/pounder/mod.rs
+++ b/src/hardware/pounder/mod.rs
@@ -3,6 +3,7 @@ use self::attenuators::AttenuatorInterface;
 use super::hal;
 use crate::hardware::{shared_adc::AdcChannel, I2c1Proxy};
 use embedded_hal::blocking::spi::Transfer;
+use enum_iterator::Sequence;
 use serde::{Deserialize, Serialize};
 
 pub mod attenuators;
@@ -13,7 +14,7 @@ pub mod rf_power;
 #[cfg(not(feature = "pounder_v1_0"))]
 pub mod timestamp;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Sequence)]
 pub enum GpioPin {
     Led4Green,
     Led5Red,
@@ -381,23 +382,7 @@ impl PounderDevices {
         // Configure power-on-default state for pounder. All LEDs are off, on-board oscillator
         // selected and enabled, attenuators out of reset. Note that testing indicates the
         // output state needs to be set first to properly update the output registers.
-        for pin in [
-            GpioPin::AttLe1,
-            GpioPin::AttLe2,
-            GpioPin::AttLe3,
-            GpioPin::AttLe0,
-            GpioPin::AttRstN,
-            GpioPin::ExtClkSel,
-            GpioPin::OscEnN,
-            GpioPin::Led4Green,
-            GpioPin::Led5Red,
-            GpioPin::Led6Green,
-            GpioPin::Led7Red,
-            GpioPin::Led8Green,
-            GpioPin::Led9Red,
-        ]
-        .into_iter()
-        {
+        for pin in enum_iterator::all::<GpioPin>() {
             devices
                 .mcp23017
                 .set_gpio(pin.into(), mcp230xx::Level::Low)

--- a/src/hardware/pounder/mod.rs
+++ b/src/hardware/pounder/mod.rs
@@ -307,7 +307,7 @@ impl ad9959::Interface for QspiInterface {
 
 /// A structure containing implementation for Pounder hardware.
 pub struct PounderDevices {
-    mcp23017: mcp230xx::MCP230xx<I2c1Proxy, mcp230xx::Mcp23017>,
+    mcp23017: mcp230xx::Mcp230xx<I2c1Proxy, mcp230xx::Mcp23017>,
     pub lm75: lm75::Lm75<I2c1Proxy, lm75::ic::Lm75>,
     attenuator_spi: hal::spi::Spi<hal::stm32::SPI1, hal::spi::Enabled, u8>,
     pwr0: AdcChannel<
@@ -345,7 +345,7 @@ impl PounderDevices {
     /// * `aux_adc1` - The ADC channel to measure the ADC1 auxiliary input.
     pub fn new(
         lm75: lm75::Lm75<I2c1Proxy, lm75::ic::Lm75>,
-        mcp23017: mcp230xx::MCP230xx<I2c1Proxy, mcp230xx::Mcp23017>,
+        mcp23017: mcp230xx::Mcp230xx<I2c1Proxy, mcp230xx::Mcp23017>,
         attenuator_spi: hal::spi::Spi<hal::stm32::SPI1, hal::spi::Enabled, u8>,
         pwr0: AdcChannel<
             'static,

--- a/src/hardware/pounder/mod.rs
+++ b/src/hardware/pounder/mod.rs
@@ -432,8 +432,7 @@ impl PounderDevices {
     ) -> Result<(), Error> {
         self.mcp23017
             .set_gpio(pin.into(), level)
-            .map_err(|_| Error::I2c)?;
-        Ok(())
+            .map_err(|_| Error::I2c)
     }
 
     /// Select external reference clock input.

--- a/src/hardware/pounder/mod.rs
+++ b/src/hardware/pounder/mod.rs
@@ -397,11 +397,11 @@ impl PounderDevices {
         {
             devices
                 .mcp23017
-                .set_direction(pin.into(), mcp230xx::Direction::Output)
+                .set_output_latch(pin.into(), level)
                 .map_err(|_| Error::I2c)?;
             devices
                 .mcp23017
-                .set_output_latch(pin.into(), level)
+                .set_direction(pin.into(), mcp230xx::Direction::Output)
                 .map_err(|_| Error::I2c)?;
         }
 

--- a/src/hardware/pounder/mod.rs
+++ b/src/hardware/pounder/mod.rs
@@ -397,7 +397,7 @@ impl PounderDevices {
         {
             devices
                 .mcp23017
-                .set_output_latch(pin.into(), level)
+                .set_gpio(pin.into(), level)
                 .map_err(|_| Error::I2c)?;
             devices
                 .mcp23017

--- a/src/hardware/pounder/mod.rs
+++ b/src/hardware/pounder/mod.rs
@@ -428,7 +428,7 @@ impl PounderDevices {
         level: mcp230xx::Level,
     ) -> Result<(), Error> {
         self.mcp23017
-            .set_output_latch(pin.into(), level)
+            .set_gpio(pin.into(), level)
             .map_err(|_| Error::I2c)?;
         Ok(())
     }

--- a/src/hardware/pounder/mod.rs
+++ b/src/hardware/pounder/mod.rs
@@ -381,26 +381,26 @@ impl PounderDevices {
         // Configure power-on-default state for pounder. All LEDs are off, on-board oscillator
         // selected and enabled, attenuators out of reset. Note that testing indicates the
         // output state needs to be set first to properly update the output registers.
-        for (pin, level) in [
-            (GpioPin::AttLe1, mcp230xx::Level::Low),
-            (GpioPin::AttLe2, mcp230xx::Level::Low),
-            (GpioPin::AttLe3, mcp230xx::Level::Low),
-            (GpioPin::AttLe0, mcp230xx::Level::Low),
-            (GpioPin::AttRstN, mcp230xx::Level::Low),
-            (GpioPin::ExtClkSel, mcp230xx::Level::Low),
-            (GpioPin::OscEnN, mcp230xx::Level::Low),
-            (GpioPin::Led4Green, mcp230xx::Level::Low),
-            (GpioPin::Led5Red, mcp230xx::Level::Low),
-            (GpioPin::Led6Green, mcp230xx::Level::Low),
-            (GpioPin::Led7Red, mcp230xx::Level::Low),
-            (GpioPin::Led8Green, mcp230xx::Level::Low),
-            (GpioPin::Led9Red, mcp230xx::Level::Low),
+        for pin in [
+            GpioPin::AttLe1,
+            GpioPin::AttLe2,
+            GpioPin::AttLe3,
+            GpioPin::AttLe0,
+            GpioPin::AttRstN,
+            GpioPin::ExtClkSel,
+            GpioPin::OscEnN,
+            GpioPin::Led4Green,
+            GpioPin::Led5Red,
+            GpioPin::Led6Green,
+            GpioPin::Led7Red,
+            GpioPin::Led8Green,
+            GpioPin::Led9Red,
         ]
         .into_iter()
         {
             devices
                 .mcp23017
-                .set_gpio(pin.into(), level)
+                .set_gpio(pin.into(), mcp230xx::Level::Low)
                 .map_err(|_| Error::I2c)?;
             devices
                 .mcp23017

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -791,7 +791,7 @@ pub fn setup(
         };
 
         let io_expander =
-            mcp230xx::MCP230xx::new_default(i2c1.acquire_i2c()).unwrap();
+            mcp230xx::Mcp230xx::new_default(i2c1.acquire_i2c()).unwrap();
 
         let temp_sensor =
             lm75::Lm75::new(i2c1.acquire_i2c(), lm75::Address::default());

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -777,7 +777,7 @@ pub fn setup(
                 ccdr.peripheral.I2C1,
                 &ccdr.clocks,
             );
-            mcp23017::MCP23017::new_default(i2c1).unwrap()
+            mcp230xx::MCP230xx::new_default(i2c1).unwrap()
         };
 
         let spi = {

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -777,7 +777,7 @@ pub fn setup(
                 ccdr.peripheral.I2C1,
                 &ccdr.clocks,
             );
-            mcp23017::MCP23017::default(i2c1).unwrap()
+            mcp23017::MCP23017::new_default(i2c1).unwrap()
         };
 
         let spi = {


### PR DESCRIPTION
I gave up trying to fix an issue where GPIO pin setting failed and refactored/rewrote the mcp23017 crate. The previous crate tried to copy the arduino library too much. Now it uses proper rust enums for pins and states, crates for bit manipulation etc. I ripped out the interrupt code which we don't use and which potentially was never tested. Overall this leads to a much more compact and maintainable crate and also here in stabilizer the API feels much better. 
It also supports the mcp23008 of @nkrackow.

* [x] `mcp230xx` [released](https://crates.io/crates/mcp230xx)
* [x] tested on fls
* [x] bump MSRV as `mcp230xx` uses the Default derive for enums.