### PR TITLE
Adding custom ASM delay implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 * Fixed panics when using a batch size of 1 ([#540](https://github.com/quartiq/stabilizer/issues/540))
+* Fixed an issue where startup delays were 1/4 of what they should be ([#524](https://github.com/quartiq/stabilizer/issues/524))
 
 ## [v0.6.0] - 2022-02-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,17 +43,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "asm-delay"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a69a963b70ddacfcd382524f72a4576f359af9334b3bf48a79566590bb8bfa"
-dependencies = [
- "bitrate",
- "cortex-m 0.7.5",
- "embedded-hal",
-]
-
-[[package]]
 name = "atomic-polyfill"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,12 +89,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitrate"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c147d86912d04bef727828fda769a76ca81629a46d8ba311a8d58a26aa91473d"
 
 [[package]]
 name = "bytemuck"
@@ -915,7 +898,6 @@ name = "stabilizer"
 version = "0.6.0"
 dependencies = [
  "ad9959",
- "asm-delay",
  "cortex-m 0.7.5",
  "cortex-m-rt",
  "cortex-m-rtic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ heapless = { version = "0.7.14", features = ["serde"] }
 cortex-m-rtic = "1.0"
 embedded-hal = "0.2.7"
 nb = "1.0.0"
-asm-delay = "0.9.0"
 num_enum = { version = "0.5.7", default-features = false }
 paste = "1"
 idsp = "0.8"

--- a/src/hardware/delay.rs
+++ b/src/hardware/delay.rs
@@ -1,0 +1,46 @@
+//! Basic blocking delay
+//!
+//! This module provides a basic asm-based blocking delay.
+//!
+//! # Note
+//! This implementation takes into account the Cortex-M7 CPU pipeline architecture to ensure delays
+//! are at least as long as specified.
+use embedded_hal::blocking::delay::{DelayMs, DelayUs};
+
+/// A basic delay implementation.
+pub struct AsmDelay {
+    frequency_us: u32,
+    frequency_ms: u32,
+}
+
+impl AsmDelay {
+    /// Create a new delay.
+    ///
+    /// # Args
+    /// * `freq` - The CPU core frequency.
+    pub fn new(freq: u32) -> AsmDelay {
+        // Note: Frequencies are scaled by 2 to account for the M7 dual instruction pipeline.
+        AsmDelay {
+            frequency_us: (freq / 1_000_000) * 2,
+            frequency_ms: (freq / 1_000) * 2,
+        }
+    }
+}
+
+impl<U> DelayUs<U> for AsmDelay
+where
+    U: Into<u32>,
+{
+    fn delay_us(&mut self, us: U) {
+        cortex_m::asm::delay(self.frequency_us * us.into())
+    }
+}
+
+impl<U> DelayMs<U> for AsmDelay
+where
+    U: Into<u32>,
+{
+    fn delay_ms(&mut self, ms: U) {
+        cortex_m::asm::delay(self.frequency_ms * ms.into())
+    }
+}

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -6,6 +6,7 @@ pub mod adc;
 pub mod afe;
 pub mod cpu_temp_sensor;
 pub mod dac;
+pub mod delay;
 pub mod design_parameters;
 pub mod input_stamper;
 pub mod pounder;

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -13,10 +13,11 @@ use stm32h7xx_hal::{
 use smoltcp_nal::smoltcp;
 
 use super::{
-    adc, afe, cpu_temp_sensor::CpuTempSensor, dac, design_parameters, eeprom,
-    input_stamper::InputStamper, pounder, pounder::dds_output::DdsOutput,
-    shared_adc::SharedAdc, timers, DigitalInput0, DigitalInput1, EthernetPhy,
-    NetworkStack, SystemTimer, Systick, AFE0, AFE1,
+    adc, afe, cpu_temp_sensor::CpuTempSensor, dac, delay, design_parameters,
+    eeprom, input_stamper::InputStamper, pounder,
+    pounder::dds_output::DdsOutput, shared_adc::SharedAdc, timers,
+    DigitalInput0, DigitalInput1, EthernetPhy, NetworkStack, SystemTimer,
+    Systick, AFE0, AFE1,
 };
 
 const NUM_TCP_SOCKETS: usize = 4;
@@ -275,9 +276,7 @@ pub fn setup(
     // After ITCM loading.
     core.SCB.enable_icache();
 
-    let mut delay = asm_delay::AsmDelay::new(asm_delay::bitrate::Hertz(
-        ccdr.clocks.c_ck().to_Hz(),
-    ));
+    let mut delay = delay::AsmDelay::new(ccdr.clocks.c_ck().to_Hz());
 
     let gpioa = device.GPIOA.split(ccdr.peripheral.GPIOA);
     let gpiob = device.GPIOB.split(ccdr.peripheral.GPIOB);


### PR DESCRIPTION
This PR fixes #524 by using a custom delay implementation that internally scales frequency x2 to account for the dual issue instruction pipeline in the M7.

Measurements were made on an oscilloscope by asserting the RX GPIO line for 200us. Pulse width measurement indicated 200.0uS was measured.