### PR TITLE
use handled_update to return path

### DIFF
--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -392,7 +392,7 @@ mod app {
     fn idle(mut c: idle::Context) -> ! {
         loop {
             match c.shared.network.lock(|net| net.update()) {
-                NetworkState::SettingsChanged => {
+                NetworkState::SettingsChanged(_path) => {
                     settings_update::spawn().unwrap()
                 }
                 NetworkState::Updated => {}

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -458,7 +458,7 @@ mod app {
     fn idle(mut c: idle::Context) -> ! {
         loop {
             match c.shared.network.lock(|net| net.update()) {
-                NetworkState::SettingsChanged => {
+                NetworkState::SettingsChanged(_path) => {
                     settings_update::spawn().unwrap()
                 }
                 NetworkState::Updated => {}


### PR DESCRIPTION
Small PR to get information about which settings path was published on during polling. Unused in `dual-iir` and `lockin`.
Enables interlock functionality for Driver. 