### PR TITLE
Nk/noise generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "regex"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +931,8 @@ dependencies = [
  "nb 1.0.0",
  "num_enum",
  "paste",
+ "rand_core",
+ "rand_xorshift",
  "rtt-logger",
  "rtt-target",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ spin = { version = "0.9", default-features = false, features = ["spin_mutex"]}
 shared-bus = "0.2"
 lm75 = "0.2"
 enum-iterator = "1.1.3"
+rand_xorshift = "0.3.0"
+rand_core = "0.6.3"
 
 [dependencies.stm32h7xx-hal]
 features = ["stm32h743v", "rt", "ethernet", "xspi"]

--- a/src/hardware/signal_generator.rs
+++ b/src/hardware/signal_generator.rs
@@ -164,7 +164,7 @@ impl SignalGenerator {
         Self {
             config,
             phase_accumulator: 0,
-            rng: XorShiftRng::from_seed([1; 16]), // initialize with arbitrary vector
+            rng: XorShiftRng::from_seed([0; 16]), // zeros will initialize with XorShiftRng internal seed
         }
     }
 

--- a/src/hardware/signal_generator.rs
+++ b/src/hardware/signal_generator.rs
@@ -165,7 +165,7 @@ impl SignalGenerator {
             config,
             phase_accumulator: 0,
             rng: XorShiftRng::from_seed([
-                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
             ]), // initialize with arbitrary vector
         }
     }

--- a/src/hardware/signal_generator.rs
+++ b/src/hardware/signal_generator.rs
@@ -176,6 +176,7 @@ impl SignalGenerator {
         self.phase_accumulator = 0;
     }
 
+    // Generate a new random number using xorshift.
     fn xorshift(&mut self) -> i32 {
         self.noise_state ^= self.noise_state << 13;
         self.noise_state ^= self.noise_state >> 17;
@@ -207,7 +208,7 @@ impl core::iter::Iterator for SignalGenerator {
                 }
             }
             Signal::Triangle => i16::MIN as i32 + (phase >> 15).abs(),
-            Signal::WhiteNoise => self.xorshift()>>16, // doesn't matter if we shift in zeros
+            Signal::WhiteNoise => self.xorshift() >> 16, // doesn't matter if we shift in zeros since signa bit is random
         };
 
         // Calculate the final output result as an i16.

--- a/src/hardware/signal_generator.rs
+++ b/src/hardware/signal_generator.rs
@@ -164,9 +164,7 @@ impl SignalGenerator {
         Self {
             config,
             phase_accumulator: 0,
-            rng: XorShiftRng::from_seed([
-                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            ]), // initialize with arbitrary vector
+            rng: XorShiftRng::from_seed([1; 16]), // initialize with arbitrary vector
         }
     }
 

--- a/src/hardware/signal_generator.rs
+++ b/src/hardware/signal_generator.rs
@@ -7,7 +7,7 @@ pub enum Signal {
     Cosine,
     Square,
     Triangle,
-    Noise,
+    WhiteNoise,
 }
 
 /// Basic configuration for a generated signal.
@@ -207,7 +207,7 @@ impl core::iter::Iterator for SignalGenerator {
                 }
             }
             Signal::Triangle => i16::MIN as i32 + (phase >> 15).abs(),
-            Signal::Noise => self.xorshift()>>16, // doesn't matter if we shift in zeros
+            Signal::WhiteNoise => self.xorshift()>>16, // doesn't matter if we shift in zeros
         };
 
         // Calculate the final output result as an i16.

--- a/src/hardware/signal_generator.rs
+++ b/src/hardware/signal_generator.rs
@@ -208,7 +208,7 @@ impl core::iter::Iterator for SignalGenerator {
                 }
             }
             Signal::Triangle => i16::MIN as i32 + (phase >> 15).abs(),
-            Signal::WhiteNoise => self.xorshift() >> 16, // doesn't matter if we shift in zeros since signa bit is random
+            Signal::WhiteNoise => self.xorshift() >> 16,
         };
 
         // Calculate the final output result as an i16.


### PR DESCRIPTION
Very simple white noise generator. The output is uniformly distributed in the signal generator amplitude setting range. Spectrum is perfectly white up to the analog frontend limit. 
16 bit xorshift leads to ripple in the spectrum.

Useful for analyzing control parameters.