### PR TITLE
Add lvds[4-7] gpio to StabilizerDevices

### DIFF
--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -35,6 +35,18 @@ pub type DigitalInput0 = hal::gpio::gpiog::PG9<hal::gpio::Input>;
 // Type alias for digital input 1 (DI1).
 pub type DigitalInput1 = hal::gpio::gpioc::PC15<hal::gpio::Input>;
 
+// Type alias for LVDS4 (digital input).
+pub type EemDigitalInput0 = hal::gpio::gpiod::PD1<hal::gpio::Input>;
+
+// Type alias for LVDS5 (digital input).
+pub type EemDigitalInput1 = hal::gpio::gpiod::PD2<hal::gpio::Input>;
+
+// Type alias for LVDS6 (digital output).
+pub type EemDigitalOutput0 = hal::gpio::gpiod::PD3<hal::gpio::Output>;
+
+// Type alias for LVDS7 (digital output).
+pub type EemDigitalOutput1 = hal::gpio::gpiod::PD4<hal::gpio::Output>;
+
 // Number of TX descriptors in the ethernet descriptor ring.
 const TX_DESRING_CNT: usize = 4;
 


### PR DESCRIPTION
We are using a stabilizer with a DIO-BNC card connected. This change facilitates access to the GPIO pins on the EEM connector without breaking existing applications.

The port assignment is 

LVDS | PortD | Direction
-- | -- | --
4 | 1 | Input
5 | 2 | Input
6 | 3 | Output
7 | 4 | Output

