### PR TITLE
[WIP]: Control Pounder through MQTT

### DIFF
--- a/ad9959/src/lib.rs
+++ b/ad9959/src/lib.rs
@@ -516,7 +516,7 @@ impl<I: Interface> Ad9959<I> {
 /// Represents a means of serializing a DDS profile for writing to a stream.
 pub struct ProfileSerializer {
     // heapless::Vec<u8, 32>, especially its extend_from_slice() is slow
-    data: [u8; 32],
+    data: [u8; 64],
     index: usize,
     // make mode u32 to work around https://github.com/japaric/heapless/issues/305
     mode: u32,
@@ -530,7 +530,7 @@ impl ProfileSerializer {
     pub fn new(mode: Mode) -> Self {
         Self {
             mode: mode as _,
-            data: [0; 32],
+            data: [0; 64],
             index: 0,
         }
     }

--- a/ad9959/src/lib.rs
+++ b/ad9959/src/lib.rs
@@ -568,6 +568,44 @@ impl ProfileSerializer {
         }
     }
 
+    /// Update the system clock configuration.
+    ///
+    /// # Args
+    /// * `channels` - A set of channels to apply the configuration to.
+    /// * `ftw` - If provided, indicates a frequency tuning word for the channels.
+    /// * `pow` - If provided, indicates a phase offset word for the channels.
+    /// * `acr` - If provided, indicates the amplitude control register for the channels. The ACR
+    ///   should be stored in the 3 LSB of the word. Note that if amplitude scaling is to be used,
+    ///   the "Amplitude multiplier enable" bit must be set.
+    #[inline]
+    pub fn update_system_clock(
+        &mut self,
+        reference_clock_frequency: f32,
+        multiplier: u8,
+    ) -> Result<f32, Error> {
+        if multiplier != 1 && !(4..=20).contains(&multiplier) {
+            return Err(Error::Bounds);
+        }
+
+        let frequency = multiplier as f32 * reference_clock_frequency as f32;
+        if frequency > 500_000_000.0f32 {
+            return Err(Error::Frequency);
+        }
+
+        // The enabled channel will be updated after clock reconfig
+        let mut fr1: [u8; 3] = [0, 0, 0];
+
+        // All FR1 fields are kept untouched except VCO & PLL divider
+        // These 2 fields will be modified anyway
+        fr1[0].set_bits(2..=6, multiplier);
+
+        let vco_range = frequency > 255e6;
+        fr1[0].set_bit(7, vco_range);
+
+        self.add_write(Register::FR1, &fr1);
+        Ok(frequency)
+    }
+
     /// Add a register write to the serialization data.
     fn add_write(&mut self, register: Register, value: &[u8]) {
         let data = &mut self.data[self.index..];

--- a/ad9959/src/lib.rs
+++ b/ad9959/src/lib.rs
@@ -46,11 +46,11 @@ pub enum Mode {
 bitflags! {
     /// Specifies an output channel of the AD9959 DDS chip.
     pub struct Channel: u8 {
-        const ONE   = 0b00010000;
-        const TWO   = 0b00100000;
-        const THREE = 0b01000000;
-        const FOUR  = 0b10000000;
-        const ALL   = Self::ONE.bits | Self::TWO.bits | Self::THREE.bits | Self::FOUR.bits;
+        const ZERO  = 0b00010000;
+        const ONE   = 0b00100000;
+        const TWO   = 0b01000000;
+        const THREE = 0b10000000;
+        const ALL   = Self::ZERO.bits | Self::ONE.bits | Self::TWO.bits | Self::THREE.bits;
     }
 }
 

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -47,8 +47,7 @@ use stabilizer::{
         pounder::{
             attenuators::AttenuatorInterface, dds_output::DdsOutput,
             rf_power::PowerMeasurementInterface, Ad9959PdhSettings,
-            Channel as PounderChannel, PDHLockGeneratorConfig,
-            PounderDevices,
+            Channel as PounderChannel, PDHLockGeneratorConfig, PounderDevices,
         },
         signal_generator::{self, SignalGenerator},
         timers::SamplingTimer,

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -537,7 +537,7 @@ mod app {
         c.shared.network.lock(|net| net.direct_stream(target));
     }
 
-    #[task(priority = 1, shared=[network, settings, telemetry], local=[cpu_temp_sensor])]
+    #[task(priority = 1, shared=[network, settings, telemetry, pounder_devices], local=[cpu_temp_sensor])]
     fn telemetry(mut c: telemetry::Context) {
         let telemetry: TelemetryBuffer =
             c.shared.telemetry.lock(|telemetry| *telemetry);
@@ -547,11 +547,30 @@ mod app {
             .settings
             .lock(|settings| (settings.afe, settings.telemetry_period));
 
+        let (pounder_temp, input_powers) =
+            c.shared.pounder_devices.lock(|pounder_dev| {
+                if let Some(dev) = pounder_dev {
+                    let input_powers = [
+                        dev.measure_power(PounderChannel::In0).unwrap(),
+                        dev.measure_power(PounderChannel::In1).unwrap(),
+                    ];
+
+                    (
+                        Some(dev.lm75.read_temperature().unwrap()),
+                        Some(input_powers),
+                    )
+                } else {
+                    (None, None)
+                }
+            });
+
         c.shared.network.lock(|net| {
             net.telemetry.publish(&telemetry.finalize(
                 gains[0],
                 gains[1],
                 c.local.cpu_temp_sensor.get_temperature().unwrap(),
+                pounder_temp,
+                input_powers,
             ))
         });
 

--- a/src/hardware/pounder/dds_output.rs
+++ b/src/hardware/pounder/dds_output.rs
@@ -157,6 +157,16 @@ impl<'a> ProfileBuilder<'a> {
         self
     }
 
+    #[inline]
+    pub fn update_system_clock(
+        &mut self,
+        reference_clock_frequency: f32,
+        multiplier: u8,
+    ) -> Result<f32, ad9959::Error> {
+        self.serializer
+            .update_system_clock(reference_clock_frequency, multiplier)
+    }
+
     /// Write the profile to the DDS asynchronously.
     #[allow(dead_code)]
     #[inline]

--- a/src/hardware/pounder/mod.rs
+++ b/src/hardware/pounder/mod.rs
@@ -129,10 +129,10 @@ impl From<Channel> for ad9959::Channel {
     /// Translate pounder channels to DDS output channels.
     fn from(other: Channel) -> Self {
         match other {
-            Channel::In0 => Self::TWO,
-            Channel::In1 => Self::FOUR,
-            Channel::Out0 => Self::ONE,
-            Channel::Out1 => Self::THREE,
+            Channel::In0 => Self::ONE,
+            Channel::Out0 => Self::ZERO,
+            Channel::In1 => Self::THREE,
+            Channel::Out1 => Self::TWO,
         }
     }
 }

--- a/src/net/telemetry.rs
+++ b/src/net/telemetry.rs
@@ -59,6 +59,12 @@ pub struct Telemetry {
 
     /// The CPU temperature in degrees Celsius.
     pub cpu_temp: f32,
+
+    /// The pounder temperature
+    pub pounder_temp: Option<f32>,
+
+    /// The detected RF power into PDH input channels
+    pub pdh_input_powers: Option<[f32; 2]>,
 }
 
 impl Default for TelemetryBuffer {
@@ -81,12 +87,21 @@ impl TelemetryBuffer {
     ///
     /// # Returns
     /// The finalized telemetry structure that can be serialized and reported.
-    pub fn finalize(self, afe0: Gain, afe1: Gain, cpu_temp: f32) -> Telemetry {
+    pub fn finalize(
+        self,
+        afe0: Gain,
+        afe1: Gain,
+        cpu_temp: f32,
+        pounder_temp: Option<f32>,
+        pdh_input_powers: Option<[f32; 2]>,
+    ) -> Telemetry {
         let in0_volts = Into::<f32>::into(self.adcs[0]) / afe0.as_multiplier();
         let in1_volts = Into::<f32>::into(self.adcs[1]) / afe1.as_multiplier();
 
         Telemetry {
             cpu_temp,
+            pounder_temp,
+            pdh_input_powers,
             adcs: [in0_volts, in1_volts],
             dacs: [self.dacs[0].into(), self.dacs[1].into()],
             digital_inputs: self.digital_inputs,


### PR DESCRIPTION
## Description
This PR implements control of devices on Pounder through MQTT.

These parameters are configurable through MQTT (topic prefix: `<prefix>/settings/pdh/ch/<n>`).
```rust
pub struct PDHChannel {
    pub osc_frequency: f32,     // Frequency of the IN/OUT DDS pair
    pub out_phase: f32,         // Phase offset of the OUT DDS channel
    pub in_phase_offset: f32,   // Phase offset of the IN DDS channel relative to the OUT DDS channel
    pub amplitude: f32,         // Amplitude of the OUT DDS channel
    pub in_attenuation: f32,    // Attenuation of the signal injected to INx connector
    pub out_attenuation: f32,   // Attenuation of the OUT DDS channel
    pub enabled: bool,          // Amplitude of the IN DDS channel (0.0 or 1.0)
}
```

Temperature reading from Pounder (LM75) & input powers (after attenuators) are reported in telemetry.

I also tried reporting power level through the LED, but I got issues like AttRstN being stuck at low voltage. I have [another branch in my fork](https://github.com/occheung/stabilizer/tree/pounder) that has working LED using the mcp23017 library.