### PR TITLE
Nk/driver output refactor

### DIFF
--- a/src/bin/driver.rs
+++ b/src/bin/driver.rs
@@ -94,13 +94,13 @@ pub struct Settings {
     /// Low noise channel output settings
     ///
     /// # Value
-    /// See [LowNoiseSettings]
+    /// See [driver::output::LowNoiseSettings]
     pub low_noise: driver::output::LowNoiseSettings,
 
     /// High power channel output settings
     ///
     /// # Value
-    /// See [HighPowerSettings]
+    /// See [driver::output::HighPowerSettings]
     pub high_power: driver::output::HighPowerSettings,
 }
 

--- a/src/bin/driver.rs
+++ b/src/bin/driver.rs
@@ -91,7 +91,7 @@ pub struct Settings {
     /// [Interlock]
     interlock: Interlock,
 
-    /// Output settings. Contains [driver::output::HighPowerSettings] 
+    /// Output settings. Contains [driver::output::HighPowerSettings]
     /// and [driver::output::LowNoiseSettings] for the respective channels.
     ///
     /// # Path
@@ -237,20 +237,8 @@ mod app {
 
     /// Main DSP processing routine.
     ///
-    /// # Note
-    /// Processing time for the DSP application code is bounded by the following constraints:
-    ///
-    /// DSP application code starts after the ADC has generated a batch of samples and must be
-    /// completed by the time the next batch of ADC samples has been acquired (plus the FIFO buffer
-    /// time). If this constraint is not met, firmware will panic due to an ADC input overrun.
-    ///
-    /// The DSP application code must also fill out the next DAC output buffer in time such that the
-    /// DAC can switch to it when it has completed the current buffer. If this constraint is not met
-    /// it's possible that old DAC codes will be generated on the output and the output samples will
-    /// be delayed by 1 batch.
-    ///
-    /// Because the ADC and DAC operate at the same rate, these two constraints actually implement
-    /// the same time bounds, meeting one also means the other is also met.
+    /// Performs an IIR processing step on a sample from Stabilizer ADC0 and generates a new output
+    /// sample for the Driver LowNoise channel. The output is also available at Stabilizer DAC0 at 1V/1A.
     #[task(binds=DMA1_STR4, local=[digital_inputs, adcs, dacs, iir_state, generator], shared=[settings, telemetry, output_state], priority=4)]
     #[link_section = ".itcm.process"]
     fn process(c: process::Context) {

--- a/src/bin/driver.rs
+++ b/src/bin/driver.rs
@@ -266,8 +266,8 @@ mod app {
                     fence(Ordering::SeqCst);
 
                     // Perform processing for  ADC channel 0 --> Driver channel 0 (LowNoise)
-                    let x = f32::from(adc0[0])
-                        * settings.afe[driver::Channel::LowNoise as usize]
+                    let x = f32::from(AdcCode(adc0[0]))
+                        / settings.afe[driver::Channel::LowNoise as usize]
                             .as_multiplier(); // get adc sample in volt * AFE gain for equivalent input voltage
                     let iir = if output[driver::Channel::LowNoise as usize]
                         .is_enabled()

--- a/src/hardware/driver/dac.rs
+++ b/src/hardware/driver/dac.rs
@@ -110,7 +110,7 @@ pub mod CONFIG2 {
 /// DAC value out of bounds error.
 #[derive(Debug)]
 pub enum Error {
-    Bounds,
+    Bounds(f32, i32),
 }
 
 /// A type representing a DAC sample.
@@ -124,7 +124,7 @@ impl DacCode {
 
 impl TryFrom<(f32, ChannelVariant)> for DacCode {
     type Error = Error;
-    /// Convert an f32 representing a current int the corresponding DAC output code for the respective channel.
+    /// Convert an f32 representing a current into the corresponding DAC output code for the respective channel.
     fn try_from(current_channel: (f32, ChannelVariant)) -> Result<Self, Error> {
         let (current, channel) = current_channel;
         let scale = channel.transimpedance()
@@ -135,7 +135,7 @@ impl TryFrom<(f32, ChannelVariant)> for DacCode {
             code ^= !(DacCode::MAX_DAC_WORD - 1);
         }
         if !(0..DacCode::MAX_DAC_WORD).contains(&code) {
-            Err(Error::Bounds)
+            Err(Error::Bounds(current, code))
         } else {
             Ok(Self((code & (DacCode::MAX_DAC_WORD - 1)) as u32))
         }

--- a/src/hardware/driver/output.rs
+++ b/src/hardware/driver/output.rs
@@ -13,21 +13,6 @@ use super::{relay::Relay, Channel};
 
 const LN_MAX_I_DEFAULT: f32 = 0.2; // default maximum current for the low noise channel in ampere
 
-#[derive(Clone, Copy, Debug, Miniconf, Default)]
-pub struct OutputSettings {
-    /// Low noise channel output settings
-    ///
-    /// # Value
-    /// See [LowNoiseSettings]
-    pub low_noise: LowNoiseSettings,
-
-    /// High power channel output settings
-    ///
-    /// # Value
-    /// See [HighPowerSettings]
-    pub high_power: HighPowerSettings,
-}
-
 #[derive(Clone, Copy, Debug, Miniconf)]
 pub struct LowNoiseSettings {
     /// Configure the IIR filter parameters. Only active once channel is enabled.

--- a/src/hardware/driver/output.rs
+++ b/src/hardware/driver/output.rs
@@ -239,7 +239,9 @@ where
             }
             // handle the ramp
             sm::States::RampCurrent => {
-                if self.context().iir.y_offset >= *target {
+                if self.context().iir.y_offset
+                    >= (*target - Output::<I2C>::RAMP_STEP)
+                {
                     self.process_event(sm::Events::RampDone).unwrap();
                 } else {
                     self.process_event(sm::Events::Tick).unwrap();

--- a/src/hardware/driver/output.rs
+++ b/src/hardware/driver/output.rs
@@ -17,17 +17,11 @@ const LN_MAX_I_DEFAULT: f32 = 0.2; // default maximum current for the low noise 
 pub struct OutputSettings {
     /// Low noise channel output settings
     ///
-    /// # Path
-    /// `low_noise`
-    ///
     /// # Value
     /// See [LowNoiseSettings]
     pub low_noise: LowNoiseSettings,
 
     /// High power channel output settings
-    ///
-    /// # Path
-    /// `high_power`
     ///
     /// # Value
     /// See [HighPowerSettings]
@@ -38,17 +32,11 @@ pub struct OutputSettings {
 pub struct LowNoiseSettings {
     /// Configure the IIR filter parameters. Only active once channel is enabled.
     ///
-    /// # Path
-    /// `iir_ch`
-    ///
     /// # Value
     /// See [iir::IIR#miniconf]
     pub iir: iir::IIR<f32>,
 
     /// Specified true if DI1 should be used as a "hold" input.
-    ///
-    /// # Path
-    /// `allow_hold`
     ///
     /// # Value
     /// "true" or "false"
@@ -56,17 +44,11 @@ pub struct LowNoiseSettings {
 
     /// Specified true if "hold" should be forced regardless of DI1 state and hold allowance.
     ///
-    /// # Path
-    /// `force_hold`
-    ///
     /// # Value
     /// "true" or "false"
     pub force_hold: bool,
 
     /// Output enabled. `True` to enable, `False` to disable.
-    ///
-    /// # Path
-    /// `output_enabled`
     ///
     /// # Value
     /// [bool]
@@ -88,17 +70,11 @@ impl Default for LowNoiseSettings {
 pub struct HighPowerSettings {
     /// Configure the output current. Only active once channel is enabled.
     ///
-    /// # Path
-    /// `current`
-    ///
     /// # Value
     /// Any positive value up to the maximum current for the high power channel.
     pub current: f32,
 
     /// Output enabled. `True` to enable, `False` to disable.
-    ///
-    /// # Path
-    /// `output_enabled`
     ///
     /// # Value
     /// bool


### PR DESCRIPTION
This PR reworks the output such that only the low noise channel is processed and updated at the sample rate.
The high power channel is only updated in `settings_update()` or during the output enable sequence.

It also adapts the miniconf settings for Driver.

I'll rework parts of the Telemetry and Streaming in the next PR, although I think I might have to cut some corners on the streaming if that takes me too long.