### PR TITLE
Nk/laser interlock

### DIFF
--- a/src/bin/driver.rs
+++ b/src/bin/driver.rs
@@ -13,6 +13,7 @@ use core::mem::MaybeUninit;
 use core::sync::atomic::{fence, Ordering};
 
 use fugit::{ExtU64, TimerInstantU64};
+use hal::gpio::PinState;
 use heapless::String;
 use mutex_trait::prelude::*;
 
@@ -152,8 +153,6 @@ pub struct Telemetry {
 
 #[rtic::app(device = stabilizer::hardware::hal::stm32, peripherals = true, dispatchers=[DCMI, JPEG, LTDC, SDMMC])]
 mod app {
-    use hal::gpio::PinState;
-
     use super::*;
 
     #[monotonic(binds = SysTick, default = true, priority = 2)]

--- a/src/hardware/design_parameters.rs
+++ b/src/hardware/design_parameters.rs
@@ -1,3 +1,4 @@
+use fugit::Duration;
 use stm32h7xx_hal::time::MegaHertz;
 
 /// The system clock, used in various timer calculations
@@ -53,3 +54,6 @@ pub const DDS_SYNC_CLK_DIV: u8 = 4;
 pub const MAX_SAMPLE_BUFFER_SIZE: usize = 32;
 
 pub type SampleBuffer = [u16; MAX_SAMPLE_BUFFER_SIZE];
+
+pub const DRIVER_MONITOR_PERIOD: Duration<u64, 1, 10000> =
+    Duration::<u64, 1, 10000>::millis(500);

--- a/src/hardware/design_parameters.rs
+++ b/src/hardware/design_parameters.rs
@@ -55,5 +55,6 @@ pub const MAX_SAMPLE_BUFFER_SIZE: usize = 32;
 
 pub type SampleBuffer = [u16; MAX_SAMPLE_BUFFER_SIZE];
 
+/// Period for checking the Driver output interlock voltage/current levels.
 pub const DRIVER_MONITOR_PERIOD: Duration<u64, 1, 10000> =
-    Duration::<u64, 1, 10000>::millis(500);
+    Duration::<u64, 1, 10000>::millis(5); // 5 ms

--- a/src/hardware/driver/interlock.rs
+++ b/src/hardware/driver/interlock.rs
@@ -25,7 +25,7 @@ pub struct Interlock {
     ///
     /// # Value
     /// "true" or "false"
-    armed: bool,
+    pub armed: bool,
 
     /// Interlock timeout in milliseconds.
     ///

--- a/src/hardware/driver/internal_adc.rs
+++ b/src/hardware/driver/internal_adc.rs
@@ -79,4 +79,13 @@ impl InternalAdc {
         const OFFSET: f32 = 0.0; // Current sense offset         ToDo
         (ratio + OFFSET) * SCALE
     }
+
+    pub fn read_all(&mut self) -> [f32; 4] {
+        [
+            self.read_output_current(Channel::LowNoise),
+            self.read_output_current(Channel::HighPower),
+            self.read_output_voltage(Channel::LowNoise),
+            self.read_output_voltage(Channel::HighPower),
+        ]
+    }
 }

--- a/src/hardware/driver/mod.rs
+++ b/src/hardware/driver/mod.rs
@@ -20,6 +20,7 @@ pub struct DriverDevices {
     pub lm75: lm75::Lm75<I2c1Proxy, lm75::ic::Lm75>,
     pub output_sm: [output::sm::StateMachine<output::Output<I2c1Proxy>>; 2],
     pub dac: [dac::Dac<Spi1Proxy>; 2],
+    pub laser_interlock_pin: hal::gpio::Pin<'B', 13, hal::gpio::Output>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, TryFromPrimitive)]

--- a/src/hardware/driver/output.rs
+++ b/src/hardware/driver/output.rs
@@ -38,6 +38,18 @@ pub struct LowNoiseSettings {
     /// # Value
     /// [bool]
     pub output_enabled: bool,
+
+    /// Configure the interlock current at which the laser interlock will trip.
+    ///
+    /// # Value
+    /// Any positive value.
+    pub interlock_current: f32,
+
+    /// Configure the interlock voltage at which the laser interlock will trip.
+    ///
+    /// # Value
+    /// Any positive value.
+    pub interlock_voltage: f32,
 }
 
 impl Default for LowNoiseSettings {
@@ -47,6 +59,8 @@ impl Default for LowNoiseSettings {
             allow_hold: false,
             force_hold: false,
             output_enabled: false,
+            interlock_current: 0.,
+            interlock_voltage: 0.,
         }
     }
 }
@@ -64,6 +78,18 @@ pub struct HighPowerSettings {
     /// # Value
     /// bool
     pub output_enabled: bool,
+
+    /// Configure the interlock current at which the laser interlock will trip.
+    ///
+    /// # Value
+    /// Any positive value.
+    pub interlock_current: f32,
+
+    /// Configure the interlock voltage at which the laser interlock will trip.
+    ///
+    /// # Value
+    /// Any positive value.
+    pub interlock_voltage: f32,
 }
 
 impl Default for HighPowerSettings {
@@ -71,6 +97,8 @@ impl Default for HighPowerSettings {
         Self {
             current: 0.0,
             output_enabled: false,
+            interlock_current: 0.,
+            interlock_voltage: 0.,
         }
     }
 }

--- a/src/hardware/driver/relay.rs
+++ b/src/hardware/driver/relay.rs
@@ -98,12 +98,12 @@ where
         };
         let mut mcp = gpio.try_lock().unwrap();
         // set GPIOs to default position
-        // mcp.set_gpio(k1_en.into(), Level::Low).unwrap();
-        // mcp.set_gpio(k1_en_n.into(), Level::High).unwrap();
-        // mcp.set_gpio(k0_d.into(), Level::Low).unwrap();
+        mcp.set_gpio(k1_en.into(), Level::Low).unwrap();
+        mcp.set_gpio(k1_en_n.into(), Level::High).unwrap();
+        mcp.set_gpio(k0_d.into(), Level::Low).unwrap();
         // toggle flipflop once to set a known output
-        // mcp.set_gpio(k0_cp.into(), Level::Low).unwrap();
-        // mcp.set_gpio(k0_cp.into(), Level::High).unwrap();
+        mcp.set_gpio(k0_cp.into(), Level::Low).unwrap();
+        mcp.set_gpio(k0_cp.into(), Level::High).unwrap();
 
         Relay {
             gpio,
@@ -118,33 +118,33 @@ where
     pub fn engage_k0(&mut self) {
         let mut mcp = self.gpio.try_lock().unwrap();
         // set flipflop data pin
-        // mcp.set_gpio(self.k0_d.into(), Level::High).unwrap();
+        mcp.set_gpio(self.k0_d.into(), Level::High).unwrap();
         // set flipflop clock input low to prepare rising edge
-        // mcp.set_gpio(self.k0_cp.into(), Level::Low).unwrap();
+        mcp.set_gpio(self.k0_cp.into(), Level::Low).unwrap();
         // set flipflop clock input high to generate rising edge
-        // mcp.set_gpio(self.k0_cp.into(), Level::High).unwrap();
+        mcp.set_gpio(self.k0_cp.into(), Level::High).unwrap();
     }
 
     // set K0 to lower position
     pub fn disengage_k0(&mut self) {
         let mut mcp = self.gpio.try_lock().unwrap();
-        // mcp.set_gpio(self.k0_d.into(), Level::High).unwrap();
-        // mcp.set_gpio(self.k0_cp.into(), Level::Low).unwrap();
-        // mcp.set_gpio(self.k0_cp.into(), Level::High).unwrap();
+        mcp.set_gpio(self.k0_d.into(), Level::High).unwrap();
+        mcp.set_gpio(self.k0_cp.into(), Level::Low).unwrap();
+        mcp.set_gpio(self.k0_cp.into(), Level::High).unwrap();
     }
 
     // set K1 to upper position
     pub fn disengage_k1(&mut self) {
         let mut mcp = self.gpio.try_lock().unwrap();
         // set en high and en _n low in order to engage K1
-        // mcp.set_gpio(self.k1_en.into(), Level::Low).unwrap();
-        // mcp.set_gpio(self.k1_en_n.into(), Level::High).unwrap();
+        mcp.set_gpio(self.k1_en.into(), Level::Low).unwrap();
+        mcp.set_gpio(self.k1_en_n.into(), Level::High).unwrap();
     }
 
     // set K1 to lower position and output current to zero
     pub fn engage_k1(&mut self) {
         let mut mcp = self.gpio.try_lock().unwrap();
-        // mcp.set_gpio(self.k1_en.into(), Level::High).unwrap();
-        // mcp.set_gpio(self.k1_en_n.into(), Level::Low).unwrap();
+        mcp.set_gpio(self.k1_en.into(), Level::High).unwrap();
+        mcp.set_gpio(self.k1_en_n.into(), Level::Low).unwrap();
     }
 }

--- a/src/hardware/driver/relay.rs
+++ b/src/hardware/driver/relay.rs
@@ -98,12 +98,12 @@ where
         };
         let mut mcp = gpio.try_lock().unwrap();
         // set GPIOs to default position
-        mcp.set_gpio(k1_en.into(), Level::Low).unwrap();
-        mcp.set_gpio(k1_en_n.into(), Level::High).unwrap();
-        mcp.set_gpio(k0_d.into(), Level::Low).unwrap();
+        // mcp.set_gpio(k1_en.into(), Level::Low).unwrap();
+        // mcp.set_gpio(k1_en_n.into(), Level::High).unwrap();
+        // mcp.set_gpio(k0_d.into(), Level::Low).unwrap();
         // toggle flipflop once to set a known output
-        mcp.set_gpio(k0_cp.into(), Level::Low).unwrap();
-        mcp.set_gpio(k0_cp.into(), Level::High).unwrap();
+        // mcp.set_gpio(k0_cp.into(), Level::Low).unwrap();
+        // mcp.set_gpio(k0_cp.into(), Level::High).unwrap();
 
         Relay {
             gpio,
@@ -118,33 +118,33 @@ where
     pub fn engage_k0(&mut self) {
         let mut mcp = self.gpio.try_lock().unwrap();
         // set flipflop data pin
-        mcp.set_gpio(self.k0_d.into(), Level::High).unwrap();
+        // mcp.set_gpio(self.k0_d.into(), Level::High).unwrap();
         // set flipflop clock input low to prepare rising edge
-        mcp.set_gpio(self.k0_cp.into(), Level::Low).unwrap();
+        // mcp.set_gpio(self.k0_cp.into(), Level::Low).unwrap();
         // set flipflop clock input high to generate rising edge
-        mcp.set_gpio(self.k0_cp.into(), Level::High).unwrap();
+        // mcp.set_gpio(self.k0_cp.into(), Level::High).unwrap();
     }
 
     // set K0 to lower position
     pub fn disengage_k0(&mut self) {
         let mut mcp = self.gpio.try_lock().unwrap();
-        mcp.set_gpio(self.k0_d.into(), Level::High).unwrap();
-        mcp.set_gpio(self.k0_cp.into(), Level::Low).unwrap();
-        mcp.set_gpio(self.k0_cp.into(), Level::High).unwrap();
+        // mcp.set_gpio(self.k0_d.into(), Level::High).unwrap();
+        // mcp.set_gpio(self.k0_cp.into(), Level::Low).unwrap();
+        // mcp.set_gpio(self.k0_cp.into(), Level::High).unwrap();
     }
 
     // set K1 to upper position
     pub fn disengage_k1(&mut self) {
         let mut mcp = self.gpio.try_lock().unwrap();
         // set en high and en _n low in order to engage K1
-        mcp.set_gpio(self.k1_en.into(), Level::Low).unwrap();
-        mcp.set_gpio(self.k1_en_n.into(), Level::High).unwrap();
+        // mcp.set_gpio(self.k1_en.into(), Level::Low).unwrap();
+        // mcp.set_gpio(self.k1_en_n.into(), Level::High).unwrap();
     }
 
     // set K1 to lower position and output current to zero
     pub fn engage_k1(&mut self) {
         let mut mcp = self.gpio.try_lock().unwrap();
-        mcp.set_gpio(self.k1_en.into(), Level::High).unwrap();
-        mcp.set_gpio(self.k1_en_n.into(), Level::Low).unwrap();
+        // mcp.set_gpio(self.k1_en.into(), Level::High).unwrap();
+        // mcp.set_gpio(self.k1_en_n.into(), Level::Low).unwrap();
     }
 }

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -1097,7 +1097,7 @@ pub fn setup(
             ),
         ];
 
-        let mut laser_interlock_pin = gpiob.pb13.into_push_pull_output();
+        let mut laser_interlock_pin = pounder_pgood.into_push_pull_output();
         laser_interlock_pin.set_low();
 
         Mezzanine::Driver(DriverDevices {

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -1097,12 +1097,16 @@ pub fn setup(
             ),
         ];
 
+        let mut laser_interlock_pin = gpiob.pb13.into_push_pull_output();
+        laser_interlock_pin.set_low();
+
         Mezzanine::Driver(DriverDevices {
             lm75,
             ltc2320,
             internal_adc,
             output_sm,
             dac,
+            laser_interlock_pin,
         })
     } else {
         Mezzanine::None


### PR DESCRIPTION
This PR adds the laser interlock. The laser interlock is tripped (pin goes low) when the interlock voltage/current is surpassed on a channel or when the thermostat interlock trips. 