### PR TITLE
Nk/fix settings update

### DIFF
--- a/py/stabilizer/iir_coefficients.py
+++ b/py/stabilizer/iir_coefficients.py
@@ -289,7 +289,7 @@ def _main():
         if len(devices) > 1:
             raise ValueError(f"Multiple prefixes discovered ({devices})."
                              "Please specify a more specific --prefix")
-        prefix = devices[0]
+        prefix = devices.pop()
         logger.info("Automatically using detected device prefix: %s", prefix)
 
     async def configure():

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -37,7 +37,7 @@ pub enum UpdateState {
 }
 
 pub enum NetworkState {
-    SettingsChanged(String<64>),
+    SettingsChanged(String<128>),
     Updated,
     NoChange,
 }
@@ -159,7 +159,8 @@ where
             UpdateState::Updated => NetworkState::Updated,
         };
 
-        let mut settings_path = String::new();
+        // `settings_path` has to be at least as large as `miniconf::mqtt_client::MAX_TOPIC_LENGTH`.
+        let mut settings_path: String<128> = String::new();
         match self.miniconf.handled_update(|path, old, new| {
             settings_path.push_str(path).unwrap();
             *old = new.clone();

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -162,7 +162,7 @@ where
         // `settings_path` has to be at least as large as `miniconf::mqtt_client::MAX_TOPIC_LENGTH`.
         let mut settings_path: String<128> = String::new();
         match self.miniconf.handled_update(|path, old, new| {
-            settings_path.push_str(path).unwrap();
+            settings_path = path.into();
             *old = new.clone();
             Result::<(), &'static str>::Ok(())
         }) {


### PR DESCRIPTION
This PR fixes two closely related bugs (that I put in):

* If a settings topic is longer than 64 chars but shorter that 128 it would panic on the `push_string().unwrap()`.
* Since the closure potentially gets called multiple times insider `handled_update()` (eg. when many retained settings come in at once) `.push_string()` continues to append every setting to `settings_path`.