### PR TITLE
Nk/interlock tele

### DIFF
--- a/src/hardware/driver/interlock.rs
+++ b/src/hardware/driver/interlock.rs
@@ -86,9 +86,9 @@ impl Interlock {
         handle_is_some: bool,
     ) -> Option<fugit::Duration<u64, 1, 10000_u32>> {
         if !handle_is_some && self.armed {
-            return Some(self.timeout.millis());
+            Some(self.timeout.millis())
         } else {
-            return None;
+            None
         }
     }
 }

--- a/src/hardware/driver/mod.rs
+++ b/src/hardware/driver/mod.rs
@@ -82,8 +82,11 @@ impl LaserInterlock {
     }
 
     pub fn set(&mut self, reason: Option<Reason>) {
-        self.pin.set_state(reason.is_none().into());
-        self.reason = reason;
+        // only update if no reason yet or if clearing (remember first reason)
+        if !self.reason.is_none() || reason.is_none() {
+            self.pin.set_state(reason.is_none().into());
+            self.reason = reason;
+        }
     }
 
     pub fn reason(&self) -> Option<Reason> {

--- a/src/hardware/driver/mod.rs
+++ b/src/hardware/driver/mod.rs
@@ -58,7 +58,7 @@ impl ChannelVariant {
 #[derive(
     Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize,
 )]
-pub enum LaserInterlockTripped {
+pub enum Reason {
     #[default]
     Reset, // Tripped after device reset
     Thermostat,
@@ -66,7 +66,7 @@ pub enum LaserInterlockTripped {
     Overvoltage(Channel),
 }
 pub struct LaserInterlock {
-    pub state: Option<LaserInterlockTripped>,
+    reason: Option<Reason>,
     pin: hal::gpio::Pin<'B', 13, hal::gpio::Output>,
 }
 
@@ -76,19 +76,23 @@ impl LaserInterlock {
     ) -> LaserInterlock {
         pin.set_low();
         LaserInterlock {
-            state: Some(LaserInterlockTripped::Reset),
+            reason: Some(Reason::Reset),
             pin,
         }
     }
 
-    pub fn set(&mut self, state: Option<LaserInterlockTripped>) {
+    pub fn set(&mut self, state: Option<Reason>) {
         match state {
-            Some(LaserInterlockTripped::Reset) => self.pin.set_low(),
-            Some(LaserInterlockTripped::Thermostat) => self.pin.set_low(),
-            Some(LaserInterlockTripped::Overcurrent(_)) => self.pin.set_low(),
-            Some(LaserInterlockTripped::Overvoltage(_)) => self.pin.set_low(),
+            Some(Reason::Reset) => self.pin.set_low(),
+            Some(Reason::Thermostat) => self.pin.set_low(),
+            Some(Reason::Overcurrent(_)) => self.pin.set_low(),
+            Some(Reason::Overvoltage(_)) => self.pin.set_low(),
             None => self.pin.set_high(),
         }
-        self.state = state;
+        self.reason = state;
+    }
+
+    pub fn reason(&self) -> Option<Reason> {
+        self.reason
     }
 }

--- a/src/hardware/driver/mod.rs
+++ b/src/hardware/driver/mod.rs
@@ -83,7 +83,7 @@ impl LaserInterlock {
 
     pub fn set(&mut self, reason: Option<Reason>) {
         // only update if no reason yet or if clearing (remember first reason)
-        if !self.reason.is_none() || reason.is_none() {
+        if self.reason.is_none() || reason.is_none() {
             self.pin.set_state(reason.is_none().into());
             self.reason = reason;
         }


### PR DESCRIPTION
This PR
* adds the laser interlock state to the telemetry. 
* refactors the laser interlock to store information about the tripping reason.
* refactors the logic of the thermostat interlock such that it can be reset by resetting the laser interlock.