### PR TITLE
Nk/driver alarm

### DIFF
--- a/src/hardware/driver/alarm.rs
+++ b/src/hardware/driver/alarm.rs
@@ -7,7 +7,7 @@ use miniconf::Miniconf;
 
 #[derive(Clone, Copy, Debug, Miniconf)]
 pub struct Alarm {
-    /// "Alarm" topic. Publishing "false" onto this topic renews the alarm timeout.
+    /// "Alarm" topic. Publish "false" onto this topic to indicate valid operating conditions. This renews the alarm timeout.
     /// Publishing "true" or failing to publish "false" for `timeout` trips the alarm.
     ///
     /// # Path

--- a/src/hardware/driver/mod.rs
+++ b/src/hardware/driver/mod.rs
@@ -61,8 +61,8 @@ impl ChannelVariant {
 pub enum Reason {
     #[default]
     Reset, // Tripped after device reset
-    ThermostatLimits,
-    ThermostatTimeout,
+    Alarm,
+    AlarmTimeout,
     Overcurrent(Channel),
     Overvoltage(Channel),
 }

--- a/src/hardware/driver/mod.rs
+++ b/src/hardware/driver/mod.rs
@@ -5,7 +5,7 @@ pub mod output;
 pub mod relay;
 use super::I2c1Proxy;
 use lm75;
-pub mod interlock;
+pub mod alarm;
 use num_enum::TryFromPrimitive;
 use serde::{Deserialize, Serialize};
 use stm32h7xx_hal as hal;
@@ -61,7 +61,8 @@ impl ChannelVariant {
 pub enum Reason {
     #[default]
     Reset, // Tripped after device reset
-    Thermostat,
+    ThermostatLimits,
+    ThermostatTimeout,
     Overcurrent(Channel),
     Overvoltage(Channel),
 }


### PR DESCRIPTION
This PR changes the thermostat interlock to "alarm". Functionality is the same with the exception that the polarity of the critical topic is flipped (alarm=true is bad while interlocked=true was good)