### PR TITLE
Removing doc requirements from bors

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -6,6 +6,5 @@ status = [
   "style",
   "compile (stable)",
   "compile (1.63.0)",
-  "doc",
   "HITL Run Status"
 ]


### PR DESCRIPTION
There's an issue with Rust where docs included in example code are not compiled in to `miniconf`. We can't fix this issue without fixing some of the core libs. As such, ignore doc requirements from Bors for now.