### PR TITLE
Nk/driver temperature shutdown

### DIFF
--- a/src/bin/driver.rs
+++ b/src/bin/driver.rs
@@ -684,7 +684,11 @@ mod app {
         channel: driver::Channel,
     ) {
         let ramp_target = c.shared.settings.lock(|settings| match channel {
-            driver::Channel::LowNoise => settings.low_noise.iir.y_offset,
+            // clamp the ramp target to the iir limits to prevent ramping to an invalid current
+            driver::Channel::LowNoise => settings.low_noise.iir.y_offset.clamp(
+                settings.low_noise.iir.y_min,
+                settings.low_noise.iir.y_max,
+            ),
             driver::Channel::HighPower => settings.high_power.current,
         });
         let reads = c.shared.telemetry.lock(|tele| {

--- a/src/bin/driver.rs
+++ b/src/bin/driver.rs
@@ -28,13 +28,12 @@
 #![no_main]
 
 use core::mem::MaybeUninit;
+use core::ops::Range;
 use core::sync::atomic::{fence, Ordering};
-
 use fugit::{Duration, ExtU64, TimerInstantU64};
 use mutex_trait::prelude::*;
 
 use idsp::iir;
-
 use serde::{Deserialize, Serialize};
 use stabilizer::hardware::driver::{LaserInterlock, Reason};
 use stabilizer::{
@@ -194,8 +193,6 @@ pub struct Telemetry {
 
 #[rtic::app(device = stabilizer::hardware::hal::stm32, peripherals = true, dispatchers=[DCMI, JPEG, LTDC, SDMMC])]
 mod app {
-    use core::ops::Range;
-
     use stabilizer::{hardware::driver::Condition, net::alarm::Change};
 
     use super::*;

--- a/src/bin/driver.rs
+++ b/src/bin/driver.rs
@@ -523,14 +523,17 @@ mod app {
         if !old_settings.reset_laser_interlock
             && new_settings.reset_laser_interlock
         {
-            if c.shared.output_state.lock(|state| {
-                state[driver::Channel::HighPower as usize].is_enabled()
-            }) {
-                log::error!("Cannot reset laser interlock while HighPower channel is enabled. Disable channel first.")
-            } else if c.shared.output_state.lock(|state| {
-                state[driver::Channel::LowNoise as usize].is_enabled()
-            }) {
-                log::error!("Cannot reset laser interlock while LowNoise channel is enabled. Disable channel first.")
+            if c.shared
+                .settings
+                .lock(|settings| settings.high_power.output_enabled)
+            {
+                log::error!("Cannot reset laser interlock while HighPower channel is enabled in settings. Disable channel first.")
+            } else if c
+                .shared
+                .settings
+                .lock(|settings| settings.low_noise.output_enabled)
+            {
+                log::error!("Cannot reset laser interlock while LowNoise channel is enabled in settings. Disable channel first.")
             } else {
                 log::info!("Laser interlock reset.");
                 c.shared.laser_interlock.lock(|ilock| {

--- a/src/bin/driver.rs
+++ b/src/bin/driver.rs
@@ -43,7 +43,7 @@ use stabilizer::{
         afe::Gain,
         dac::{Dac0Output, Dac1Output, DacCode},
         design_parameters, driver,
-        driver::{output, Channel},
+        driver::{output, Channel, Condition, Location, Temperature},
         hal,
         timers::SamplingTimer,
         DigitalInput0, DigitalInput1, I2c1Proxy, SystemTimer, Systick, AFE0,
@@ -51,6 +51,7 @@ use stabilizer::{
     },
     net::{
         alarm,
+        alarm::Change,
         data_stream::{FrameGenerator, StreamFormat, StreamTarget},
         miniconf::Miniconf,
         NetworkState, NetworkUsers,
@@ -193,8 +194,6 @@ pub struct Telemetry {
 
 #[rtic::app(device = stabilizer::hardware::hal::stm32, peripherals = true, dispatchers=[DCMI, JPEG, LTDC, SDMMC])]
 mod app {
-    use stabilizer::{hardware::driver::Condition, net::alarm::Change};
-
     use super::*;
 
     /// Period for checking the Driver output interlock voltage/current levels.
@@ -325,6 +324,7 @@ mod app {
         header_adc_start_conversion::spawn().unwrap();
         start::spawn_after(100.millis()).unwrap();
         monitor_output::spawn_after(DRIVER_MONITOR_PERIOD).unwrap();
+        monitor_temperature::spawn().unwrap();
 
         (shared, local, init::Monotonics(stabilizer.systick))
     }
@@ -624,21 +624,14 @@ mod app {
         };
     }
 
-    #[task(priority = 1, shared=[network, settings, telemetry, laser_interlock], local=[cpu_temp_sensor, driver_temp, header_temp])]
+    #[task(priority = 1, shared=[network, settings, telemetry, laser_interlock], local=[cpu_temp_sensor])]
     fn telemetry(mut c: telemetry::Context) {
         let mut telemetry: Telemetry =
             c.shared.telemetry.lock(|telemetry| telemetry.clone());
 
         telemetry.monitor.cpu_temp =
             c.local.cpu_temp_sensor.get_temperature().unwrap();
-        telemetry.monitor.driver_temp =
-            c.local.driver_temp.read_temperature().unwrap();
 
-        #[cfg(feature = "ai_artiq_laser_module")]
-        {
-            telemetry.monitor.header_temp =
-                c.local.header_temp.read_temperature().unwrap();
-        }
         telemetry.interlock_tripped =
             c.shared.laser_interlock.lock(|ilock| ilock.reason());
         let telemetry_period = c
@@ -863,7 +856,7 @@ mod app {
                 (c.shared.laser_interlock).lock(|ilock| {
                     c.shared.output_state.lock(|state| {
                         let delays = ilock.set(
-                            Some(Reason::Overcurrent(Condition {
+                            Some(Reason::Overvoltage(Condition {
                                 channel: ch,
                                 threshold: *interlock_voltage,
                                 read: *read,
@@ -888,6 +881,57 @@ mod app {
             tele.monitor.voltage = voltage_reads;
         });
         monitor_output::spawn_after(DRIVER_MONITOR_PERIOD).unwrap();
+    }
+
+    #[task(priority = 1, shared=[telemetry, laser_interlock, output_state], local=[driver_temp, header_temp])]
+    fn monitor_temperature(mut c: monitor_temperature::Context) {
+        /// Period for checking the Driver and header board temperatures.
+        pub const TEMPERATURE_MONITOR_PERIOD: Duration<u64, 1, 10000> =
+            Duration::<u64, 1, 10000>::millis(1000); // 1 s
+
+        /// Acceptable temperature range for Driver and the header board. This has to be relatively conservative
+        /// so we can react quickly to a runaway heating condition before Driver gets damaged.
+        pub const VALID_TEMP_RANGE: Range<f32> = -10.0..50.0;
+
+        let temps = [
+            c.local.driver_temp.read_temperature().unwrap(),
+            c.local.header_temp.read_temperature().unwrap(),
+        ];
+
+        [Location::Driver, Location::LaserModuleHeadboard]
+            .iter()
+            .zip(temps)
+            .for_each(|(loc, temp)| {
+                if !VALID_TEMP_RANGE.contains(&temp) {
+                    (c.shared.laser_interlock).lock(|ilock| {
+                        c.shared.output_state.lock(|state| {
+                            let delays = ilock.set(
+                                Some(Reason::Overtemperature(Temperature {
+                                    location: *loc,
+                                    valid_range: VALID_TEMP_RANGE,
+                                    read: temp,
+                                })),
+                                state,
+                            );
+                            delays.iter().enumerate().for_each(|(i, delay)| {
+                                if let Some(delay) = delay {
+                                    handle_output_tick::spawn_after(
+                                        delay.convert(),
+                                        Channel::try_from(i).unwrap(),
+                                    )
+                                    .unwrap();
+                                }
+                            });
+                        });
+                    });
+                }
+            });
+
+        c.shared.telemetry.lock(|telemetry| {
+            telemetry.monitor.driver_temp = temps[0];
+            telemetry.monitor.header_temp = temps[1];
+        });
+        monitor_temperature::spawn_after(TEMPERATURE_MONITOR_PERIOD).unwrap();
     }
 
     #[task(binds = ETH, priority = 1)]

--- a/src/hardware/driver/mod.rs
+++ b/src/hardware/driver/mod.rs
@@ -134,10 +134,14 @@ impl LaserInterlock {
             self.pin.set_state(reason.is_none().into());
             // disable both outputs if interlock is tripped
             self.reason = reason;
-            [
-                output_state[0].set_enable(false).unwrap(),
-                output_state[1].set_enable(false).unwrap(),
-            ]
+            if self.reason.is_some() {
+                [
+                    output_state[0].set_enable(false).unwrap(),
+                    output_state[1].set_enable(false).unwrap(),
+                ]
+            } else {
+                [None, None]
+            }
         } else {
             [None, None]
         }

--- a/src/hardware/driver/mod.rs
+++ b/src/hardware/driver/mod.rs
@@ -123,10 +123,21 @@ impl LaserInterlock {
         }
     }
 
-    pub fn set(&mut self, reason: Option<Reason>) {
+    pub fn set(
+        &mut self,
+        reason: Option<Reason>,
+        // output_state: &mut [output::sm::StateMachine<output::Output<I2c1Proxy>>;
+        //          2],
+    ) {
         // only update if no reason yet or if clearing (remember first reason)
         if self.reason.is_none() || reason.is_none() {
             self.pin.set_state(reason.is_none().into());
+            // disable both outputs if interlock is tripped
+            // output_state.iter().map(|state| {
+            //     if reason.is_some() {
+            //         state.set_enable(false);
+            //     }
+            // });
             self.reason = reason;
         }
     }

--- a/src/hardware/driver/mod.rs
+++ b/src/hardware/driver/mod.rs
@@ -53,7 +53,7 @@ impl ChannelVariant {
 
     /// Returns the effective scale of the DAC output voltage to the channel output current.
     /// The scale is negative for source channels since a lower DAC voltage leads to more current.
-    fn dac_to_output_current_scale(&self) -> f32 {
+    pub fn dac_to_output_current_scale(&self) -> f32 {
         match self {
             ChannelVariant::LowNoiseSource => -Self::R_SHUNT_LN, // negated
             ChannelVariant::LowNoiseSink => Self::R_SHUNT_LN,

--- a/src/hardware/driver/mod.rs
+++ b/src/hardware/driver/mod.rs
@@ -53,7 +53,7 @@ impl ChannelVariant {
 
     /// Returns the effective scale of the DAC output voltage to the channel output current.
     /// The scale is negative for source channels since a lower DAC voltage leads to more current.
-    pub fn dac_to_output_current_scale(&self) -> f32 {
+    fn dac_to_output_current_scale(&self) -> f32 {
         match self {
             ChannelVariant::LowNoiseSource => -Self::R_SHUNT_LN, // negated
             ChannelVariant::LowNoiseSink => Self::R_SHUNT_LN,

--- a/src/hardware/driver/mod.rs
+++ b/src/hardware/driver/mod.rs
@@ -126,18 +126,18 @@ impl LaserInterlock {
     pub fn set(
         &mut self,
         reason: Option<Reason>,
-        // output_state: &mut [output::sm::StateMachine<output::Output<I2c1Proxy>>;
-        //          2],
+        output_state: Option<
+            &mut [output::sm::StateMachine<output::Output<I2c1Proxy>>; 2],
+        >,
     ) {
         // only update if no reason yet or if clearing (remember first reason)
         if self.reason.is_none() || reason.is_none() {
             self.pin.set_state(reason.is_none().into());
             // disable both outputs if interlock is tripped
-            // output_state.iter().map(|state| {
-            //     if reason.is_some() {
-            //         state.set_enable(false);
-            //     }
-            // });
+            if let Some(state) = output_state {
+                state[0].set_enable(false).unwrap();
+                state[1].set_enable(false).unwrap();
+            }
             self.reason = reason;
         }
     }

--- a/src/hardware/driver/mod.rs
+++ b/src/hardware/driver/mod.rs
@@ -126,19 +126,20 @@ impl LaserInterlock {
     pub fn set(
         &mut self,
         reason: Option<Reason>,
-        output_state: Option<
-            &mut [output::sm::StateMachine<output::Output<I2c1Proxy>>; 2],
-        >,
-    ) {
+        output_state: &mut [output::sm::StateMachine<output::Output<I2c1Proxy>>;
+                 2],
+    ) -> [Option<fugit::MillisDuration<u64>>; 2] {
         // only update if no reason yet or if clearing (remember first reason)
         if self.reason.is_none() || reason.is_none() {
             self.pin.set_state(reason.is_none().into());
             // disable both outputs if interlock is tripped
-            if let Some(state) = output_state {
-                state[0].set_enable(false).unwrap();
-                state[1].set_enable(false).unwrap();
-            }
             self.reason = reason;
+            [
+                output_state[0].set_enable(false).unwrap(),
+                output_state[1].set_enable(false).unwrap(),
+            ]
+        } else {
+            [None, None]
         }
     }
 

--- a/src/hardware/driver/mod.rs
+++ b/src/hardware/driver/mod.rs
@@ -4,6 +4,8 @@ pub mod ltc2320;
 pub mod output;
 pub mod relay;
 
+use core::ops::Range;
+
 use self::output::SelfTest;
 use super::I2c1Proxy;
 use idsp::iir;
@@ -84,6 +86,19 @@ pub struct Condition {
     pub read: f32,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Temperature {
+    pub location: Location,
+    pub valid_range: Range<f32>,
+    pub read: f32,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub enum Location {
+    Driver,
+    LaserModuleHeadboard,
+}
+
 /// A [Reason] why the interlock has tripped.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub enum Reason {
@@ -106,6 +121,11 @@ pub enum Reason {
     /// The device selftest during the channel enabling sequence failed.
     /// See [output::FailReason] for details.
     Selftest(SelfTest),
+
+    /// There was an overtemperature condition on Driver or the laser module headboard.
+    /// This is detected using LM75 temperature sensor ICs on the PCB and doesn't reflect the actual
+    /// worst case temperature on eg. the Driver heatsink.
+    Overtemperature(Temperature),
 }
 pub struct LaserInterlock {
     reason: Option<Reason>,

--- a/src/hardware/driver/output.rs
+++ b/src/hardware/driver/output.rs
@@ -195,7 +195,7 @@ pub mod sm {
             RampCurrent + RampDone = Enabled,
 
             // Abort transitions
-            EnableWaitK0 | EnableWaitK1 | RampCurrent + Disable = Abort,
+            EnableWaitK0 | EnableWaitK1 | RampCurrent | SelftestZero | SelftestShunt | SelftestShort + Disable = Abort,
             Abort + Tick / disengage_k1_and_hold_iir = DisableWaitK1,
 
             // Disable sequence

--- a/src/hardware/driver/output.rs
+++ b/src/hardware/driver/output.rs
@@ -156,7 +156,7 @@ where
     const LN_VALID_CURRENT_SHOTTKY: Range<f32> = 0.009..0.011; // 9 mA to 11 mA
     const LN_VALID_VOLTAGE_ZERO: Range<f32> = -0.05..0.05; // -50 mV to 50 mV
     const LN_VALID_VOLTAGE_SHUNT: Range<f32> = 0.05..0.15; // 50 mV to 150 mV (10 ohm shunt resistor)
-    const LN_VALID_VOLTAGE_SHOTTKY: Range<f32> = 0.2..0.3; // 200 mV to 300 mV (approximalte voltage drop over shottky to GND)
+    const LN_VALID_VOLTAGE_SHOTTKY: Range<f32> = 0.2..0.4; // 200 mV to 400 mV (approximalte voltage drop over shottky to GND)
 
     // The current measurements on the HP side are very inaccurate right now.
     const HP_VALID_CURRENT_ZERO: Range<f32> = 0.0..1.;

--- a/src/hardware/driver/output.rs
+++ b/src/hardware/driver/output.rs
@@ -266,7 +266,9 @@ where
             true => sm::Events::Enable,
             false => sm::Events::Disable,
         };
-        if *self.process_event(event)? != sm::States::Abort {
+        if ![sm::States::Abort, sm::States::Disabled]
+            .contains(self.process_event(event)?)
+        {
             Ok(Some(Output::<I2C>::SET_DELAY))
         } else {
             Ok(None)


### PR DESCRIPTION
This PR adds a temperature monitoring task to check the Driver and headboard temperatures and turn off the channels to prevent runaway heating and damage in Driver. https://github.com/sinara-hw/Driver/issues/18

It was thereby necessary to refactor the way the interlock works by adding the feature that tripping the interlock implicitly also turns off both channels (aka triggers the state machines to transition through to the `Disabled` state). This means that the miniconf `output_enabled` state for both channels can be out of sync with the actual output state machine. This is a necessary sacrifice to be able to turn off the outputs and I think it doesn't matter that much. 
You still have to first set the miniconf setting to disabled first before resetting the laser interlock. So nothing changed from a users perspective except for no self destruction during a high output current interlock event. 
implements https://github.com/quartiq/stabilizer/issues/706