### PR TITLE
Preparing to rename master to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [master, staging, trying]
+    branches: [main, staging, trying]
   pull_request:
-    branches: [master]
+    branches: [main]
   schedule:
     # UTC
     - cron: '48 4 * * *'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: "Pull Request Labeler"
 on:
   pull_request_target:
-    branches: [master]
+    branches: [main]
 
 jobs:
   labeler:

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   release-docs:


### PR DESCRIPTION
Preparing to rename `master` to `main` to support a unified HITL infrastructure for QUARTIQ hardware