### PR TITLE
Continue-on-error for Beta toolchain builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
   compile:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.toolchain == 'nightly' }}
+    continue-on-error: ${{ matrix.toolchain == 'nightly' || matrix.toolchain == 'beta'}}
     strategy:
       matrix:
         # keep MSRV in sync in ci.yaml and Cargo.toml


### PR DESCRIPTION
Fixes an issue where `beta` toolchain failures were causing CI to abort early.

It's currently suspected that the `beta` toolchain is hitting OOM errors on the Github hosted runner