### PR TITLE
Enforcing HITL pass requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,12 @@ jobs:
             {"github": ${{ toJson(github) }}, "check_id": ${{steps.hitl-check.outputs.check_id}}}
 
       - uses: fountainhead/action-wait-for-check@v1.0.0
+        id: status
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: HITL Run Status
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: "Check HITL Status"
+        if: steps.status.outputs.conclusion != 'success'
+        run: exit -1


### PR DESCRIPTION
Fixes #760 by mirroring the HITL run result to the `hitl-trigger` check. Previously, `hitl-trigger` was successful when the HITL triggered and finished, regardless of the exit status.