### PR TITLE
stream: make batch_size be the size in bytes

### DIFF
--- a/py/stabilizer/stream.py
+++ b/py/stabilizer/stream.py
@@ -45,7 +45,7 @@ class AdcDac:
 
     def batch_count(self):
         """Return the number of batches in the frame"""
-        return self.size() // (4 * 2 * self.header.batch_size)
+        return self.size() // self.header.batch_size
 
     def size(self):
         """Return the data size of the frame in bytes"""
@@ -54,7 +54,8 @@ class AdcDac:
     def to_mu(self):
         """Return the raw data in machine units"""
         data = np.frombuffer(self.body, "<i2")
-        data = data.reshape(-1, 4, self.header.batch_size)
+        # batch, channel, sample
+        data = data.reshape(-1, 4, self.header.batch_size // (4 * 2))
         data = data.swapaxes(0, 1).reshape(4, -1)
         # convert DAC offset binary to two's complement
         data[2:] ^= np.int16(0x8000)

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -226,8 +226,10 @@ mod app {
                 .unwrap(),
         );
 
-        let generator = network
-            .configure_streaming(StreamFormat::AdcDacData, BATCH_SIZE as _);
+        let generator = network.configure_streaming(
+            StreamFormat::AdcDacData,
+            (BATCH_SIZE * core::mem::size_of::<i16>() * 4) as _,
+        );
 
         let settings = Settings::default();
 
@@ -359,7 +361,7 @@ mod app {
                     // Stream the data.
                     const N: usize = BATCH_SIZE * core::mem::size_of::<i16>()
                         / core::mem::size_of::<MaybeUninit<u8>>();
-                    generator.add::<_, { N * 4 }>(|buf| {
+                    generator.add(|buf| {
                         for (data, buf) in adc_samples
                             .iter()
                             .chain(dac_samples.iter())

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -266,8 +266,10 @@ mod app {
                 .unwrap(),
         );
 
-        let generator = network
-            .configure_streaming(StreamFormat::AdcDacData, BATCH_SIZE as _);
+        let generator = network.configure_streaming(
+            StreamFormat::AdcDacData,
+            (BATCH_SIZE * core::mem::size_of::<i16>() * 4) as _,
+        );
 
         let shared = Shared {
             network,
@@ -425,7 +427,7 @@ mod app {
                 // Stream the data.
                 const N: usize = BATCH_SIZE * core::mem::size_of::<i16>()
                     / core::mem::size_of::<MaybeUninit<u8>>();
-                generator.add::<_, { N * 4 }>(|buf| {
+                generator.add(|buf| {
                     for (data, buf) in adc_samples
                         .iter()
                         .chain(dac_samples.iter())


### PR DESCRIPTION
This allows the break up into batches to become independent of the
stream format
