### PR TITLE
Adding support for DNS-based brokers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,8 @@ dependencies = [
 [[package]]
 name = "minimq"
 version = "0.7.0"
-source = "git+https://github.com/quartiq/minimq?branch=feature/dns-brokers#93aa7cc2f29ca7d1239ffa7716055a333fad7c75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0106439fe4eb2e88c5b6b8fcb505b2f679bd8e105c947aa1f1a77f6b57a38653"
 dependencies = [
  "bit_field",
  "embedded-nal",
@@ -458,7 +459,7 @@ dependencies = [
 [[package]]
 name = "minimq"
 version = "0.7.0"
-source = "git+https://github.com/quartiq/minimq#8e7e2b8c6faf72b87a630b0c2a0571a8d117f187"
+source = "git+https://github.com/quartiq/minimq?branch=feature/dns-brokers#93aa7cc2f29ca7d1239ffa7716055a333fad7c75"
 dependencies = [
  "bit_field",
  "embedded-nal",
@@ -875,7 +876,7 @@ dependencies = [
 [[package]]
 name = "smoltcp-nal"
 version = "0.4.0"
-source = "git+https://github.com/quartiq/smoltcp-nal?branch=feature/dns-support#ef39367621826ed4a32257b174ced5bdcb4a12e6"
+source = "git+https://github.com/quartiq/smoltcp-nal?branch=feature/dns-support#8092b7b7757474bf66e9dcb0fd6168a06ab8d1a7"
 dependencies = [
  "embedded-nal",
  "embedded-time",
@@ -911,7 +912,7 @@ dependencies = [
  "log",
  "mcp230xx",
  "miniconf",
- "minimq 0.7.0 (git+https://github.com/quartiq/minimq)",
+ "minimq 0.7.0 (git+https://github.com/quartiq/minimq?branch=feature/dns-brokers)",
  "mono-clock",
  "mutex-trait",
  "num_enum 0.7.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,8 +443,7 @@ dependencies = [
 [[package]]
 name = "minimq"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0106439fe4eb2e88c5b6b8fcb505b2f679bd8e105c947aa1f1a77f6b57a38653"
+source = "git+https://github.com/quartiq/minimq?branch=feature/dns-brokers#93aa7cc2f29ca7d1239ffa7716055a333fad7c75"
 dependencies = [
  "bit_field",
  "embedded-nal",
@@ -861,8 +860,7 @@ dependencies = [
 [[package]]
 name = "smoltcp-nal"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75077a28569d93c2eed77164fd36dd224a9efcf6ecf0e574f293ed638783b000"
+source = "git+https://github.com/quartiq/smoltcp-nal?branch=feature/dns-support#ef39367621826ed4a32257b174ced5bdcb4a12e6"
 dependencies = [
  "embedded-nal",
  "embedded-time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,13 +416,13 @@ dependencies = [
 [[package]]
 name = "miniconf"
 version = "0.8.0"
-source = "git+https://github.com/quartiq/miniconf?branch=feature/minimq-update#e0d4d4b4c38fdd1c79cbfc2044e3800dd16c53ce"
+source = "git+https://github.com/quartiq/miniconf#61946c1a739abb79870fedcb096c5cd697eee361"
 dependencies = [
  "heapless",
  "itoa",
  "log",
  "miniconf_derive",
- "minimq 0.7.0 (git+https://github.com/quartiq/minimq)",
+ "minimq",
  "serde",
  "serde-json-core",
  "smlang",
@@ -431,7 +431,7 @@ dependencies = [
 [[package]]
 name = "miniconf_derive"
 version = "0.8.0"
-source = "git+https://github.com/quartiq/miniconf?branch=feature/minimq-update#e0d4d4b4c38fdd1c79cbfc2044e3800dd16c53ce"
+source = "git+https://github.com/quartiq/miniconf#61946c1a739abb79870fedcb096c5cd697eee361"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -441,22 +441,7 @@ dependencies = [
 [[package]]
 name = "minimq"
 version = "0.7.0"
-source = "git+https://github.com/quartiq/minimq?branch=master#2b466aa1bd7377d59ba58f76172bdd3422d5570c"
-dependencies = [
- "bit_field",
- "embedded-nal",
- "embedded-time",
- "heapless",
- "num_enum 0.5.11",
- "serde",
- "smlang",
- "varint-rs",
-]
-
-[[package]]
-name = "minimq"
-version = "0.7.0"
-source = "git+https://github.com/quartiq/minimq#2b466aa1bd7377d59ba58f76172bdd3422d5570c"
+source = "git+https://github.com/quartiq/minimq#f4cb420186fb6f294ffdaa612bb8401c3261fd63"
 dependencies = [
  "bit_field",
  "embedded-nal",
@@ -910,7 +895,7 @@ dependencies = [
  "log",
  "mcp230xx",
  "miniconf",
- "minimq 0.7.0 (git+https://github.com/quartiq/minimq?branch=master)",
+ "minimq",
  "mono-clock",
  "mutex-trait",
  "num_enum 0.7.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,14 +416,13 @@ dependencies = [
 [[package]]
 name = "miniconf"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e34fb3249ad071debda2ceb8d29e271d0fd283039f7bf04d9d7921dec4e6b4e"
+source = "git+https://github.com/quartiq/miniconf?branch=feature/minimq-update#e0d4d4b4c38fdd1c79cbfc2044e3800dd16c53ce"
 dependencies = [
  "heapless",
  "itoa",
  "log",
  "miniconf_derive",
- "minimq 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "minimq 0.7.0 (git+https://github.com/quartiq/minimq)",
  "serde",
  "serde-json-core",
  "smlang",
@@ -432,8 +431,7 @@ dependencies = [
 [[package]]
 name = "miniconf_derive"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2327f540b14c86184b066abe25daca988c15c60f0d9a215d2a37f3032805d47"
+source = "git+https://github.com/quartiq/miniconf?branch=feature/minimq-update#e0d4d4b4c38fdd1c79cbfc2044e3800dd16c53ce"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -443,8 +441,7 @@ dependencies = [
 [[package]]
 name = "minimq"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0106439fe4eb2e88c5b6b8fcb505b2f679bd8e105c947aa1f1a77f6b57a38653"
+source = "git+https://github.com/quartiq/minimq?branch=master#2b466aa1bd7377d59ba58f76172bdd3422d5570c"
 dependencies = [
  "bit_field",
  "embedded-nal",
@@ -459,7 +456,7 @@ dependencies = [
 [[package]]
 name = "minimq"
 version = "0.7.0"
-source = "git+https://github.com/quartiq/minimq?branch=feature/dns-brokers#93aa7cc2f29ca7d1239ffa7716055a333fad7c75"
+source = "git+https://github.com/quartiq/minimq#2b466aa1bd7377d59ba58f76172bdd3422d5570c"
 dependencies = [
  "bit_field",
  "embedded-nal",
@@ -875,8 +872,9 @@ dependencies = [
 
 [[package]]
 name = "smoltcp-nal"
-version = "0.4.0"
-source = "git+https://github.com/quartiq/smoltcp-nal?branch=feature/dns-support#8092b7b7757474bf66e9dcb0fd6168a06ab8d1a7"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd2ed2f8e7643a170506863ed0f52ad1dc5762abdcff27de825dde14fc8025f"
 dependencies = [
  "embedded-nal",
  "embedded-time",
@@ -912,7 +910,7 @@ dependencies = [
  "log",
  "mcp230xx",
  "miniconf",
- "minimq 0.7.0 (git+https://github.com/quartiq/minimq?branch=feature/dns-brokers)",
+ "minimq 0.7.0 (git+https://github.com/quartiq/minimq?branch=master)",
  "mono-clock",
  "mutex-trait",
  "num_enum 0.7.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "minimq"
 version = "0.7.0"
-source = "git+https://github.com/quartiq/minimq#f4cb420186fb6f294ffdaa612bb8401c3261fd63"
+source = "git+https://github.com/quartiq/minimq#008fe6305b263046cabe296a64518cd99e597e35"
 dependencies = [
  "bit_field",
  "embedded-nal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,17 +59,13 @@ lm75 = "0.2"
 enum-iterator = "1.4.1"
 rand_xorshift = "0.3.0"
 rand_core = "0.6.4"
-minimq = {git = "https://github.com/quartiq/minimq", branch = "feature/dns-brokers"}
-miniconf = "0.8"
-smoltcp-nal = { version = "0.4", features = ["shared-stack"]}
+minimq = {git = "https://github.com/quartiq/minimq", branch = "master"}
+miniconf = {git="https://github.com/quartiq/miniconf", branch = "feature/minimq-update"}
+smoltcp-nal = { version = "0.4.1", features = ["shared-stack"]}
 
 [dependencies.stm32h7xx-hal]
 git = "https://github.com/stm32-rs/stm32h7xx-hal"
 features = ["stm32h743v", "rt", "ethernet", "xspi"]
-
-[patch.crates-io.smoltcp-nal]
-git = "https://github.com/quartiq/smoltcp-nal"
-branch = "feature/dns-support"
 
 [features]
 nightly = [ ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,14 @@ smoltcp-nal = { version = "0.4", features = ["shared-stack"]}
 git = "https://github.com/stm32-rs/stm32h7xx-hal"
 features = ["stm32h743v", "rt", "ethernet", "xspi"]
 
+[patch.crates-io.smoltcp-nal]
+git = "https://github.com/quartiq/smoltcp-nal"
+branch = "feature/dns-support"
+
+[patch.crates-io.minimq]
+git = "https://github.com/quartiq/minimq"
+branch = "feature/dns-brokers"
+
 [features]
 nightly = [ ]
 pounder_v1_0 = [ ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,8 @@ lm75 = "0.2"
 enum-iterator = "1.4.1"
 rand_xorshift = "0.3.0"
 rand_core = "0.6.4"
-minimq = {git = "https://github.com/quartiq/minimq", branch = "master"}
-miniconf = {git="https://github.com/quartiq/miniconf", branch = "feature/minimq-update"}
+minimq = {git = "https://github.com/quartiq/minimq"}
+miniconf = {git="https://github.com/quartiq/miniconf"}
 smoltcp-nal = { version = "0.4.1", features = ["shared-stack"]}
 
 [dependencies.stm32h7xx-hal]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ lm75 = "0.2"
 enum-iterator = "1.4.1"
 rand_xorshift = "0.3.0"
 rand_core = "0.6.4"
-minimq = {git = "https://github.com/quartiq/minimq"}
+minimq = {git = "https://github.com/quartiq/minimq", branch = "feature/dns-brokers"}
 miniconf = "0.8"
 smoltcp-nal = { version = "0.4", features = ["shared-stack"]}
 
@@ -70,10 +70,6 @@ features = ["stm32h743v", "rt", "ethernet", "xspi"]
 [patch.crates-io.smoltcp-nal]
 git = "https://github.com/quartiq/smoltcp-nal"
 branch = "feature/dns-support"
-
-[patch.crates-io.minimq]
-git = "https://github.com/quartiq/minimq"
-branch = "feature/dns-brokers"
 
 [features]
 nightly = [ ]

--- a/py/setup.py
+++ b/py/setup.py
@@ -15,6 +15,6 @@ setup(
         "matplotlib",
         "gmqtt",
         # Keep this synced with the miniconf version in Cargo.toml
-        "miniconf-mqtt@git+https://github.com/quartiq/miniconf@master#subdirectory=py/miniconf-mqtt",
+        "miniconf-mqtt@git+https://github.com/quartiq/miniconf@main#subdirectory=py/miniconf-mqtt",
     ],
 )

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -220,7 +220,7 @@ mod app {
             clock,
             env!("CARGO_BIN_NAME"),
             stabilizer.net.mac_address,
-            option_env!("BROKER").unwrap_or("10.34.16.10"),
+            option_env!("BROKER").unwrap_or("mqtt"),
         );
 
         let generator = network.configure_streaming(StreamFormat::AdcDacData);

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -50,7 +50,7 @@ use stabilizer::{
     },
     net::{
         data_stream::{FrameGenerator, StreamFormat, StreamTarget},
-        miniconf::Miniconf,
+        miniconf::Tree,
         telemetry::{Telemetry, TelemetryBuffer},
         NetworkState, NetworkUsers,
     },
@@ -71,7 +71,7 @@ const SAMPLE_TICKS: u32 = 1 << SAMPLE_TICKS_LOG2;
 const SAMPLE_PERIOD: f32 =
     SAMPLE_TICKS as f32 * hardware::design_parameters::TIMER_PERIOD;
 
-#[derive(Clone, Copy, Debug, Miniconf)]
+#[derive(Clone, Copy, Debug, Tree)]
 pub struct Settings {
     /// Configure the Analog Front End (AFE) gain.
     ///
@@ -82,7 +82,7 @@ pub struct Settings {
     ///
     /// # Value
     /// Any of the variants of [Gain] enclosed in double quotes.
-    #[miniconf(defer)]
+    #[tree]
     afe: [Gain; 2],
 
     /// Configure the IIR filter parameters.
@@ -95,7 +95,7 @@ pub struct Settings {
     ///
     /// # Value
     /// See [iir::IIR#miniconf]
-    #[miniconf(defer(2))]
+    #[tree]
     iir_ch: [[iir::IIR<f32>; IIR_CASCADE_LENGTH]; 2],
 
     /// Specified true if DI1 should be used as a "hold" input.
@@ -143,7 +143,7 @@ pub struct Settings {
     ///
     /// # Value
     /// See [signal_generator::BasicConfig#miniconf]
-    #[miniconf(defer(2))]
+    #[tree]
     signal_generator: [signal_generator::BasicConfig; 2],
 }
 
@@ -182,7 +182,7 @@ mod app {
 
     #[shared]
     struct Shared {
-        network: NetworkUsers<Settings, Telemetry, 3>,
+        network: NetworkUsers<Settings, Telemetry, 2>,
 
         settings: Settings,
         telemetry: TelemetryBuffer,
@@ -220,10 +220,6 @@ mod app {
             clock,
             env!("CARGO_BIN_NAME"),
             stabilizer.net.mac_address,
-            option_env!("BROKER")
-                .unwrap_or("10.34.16.1")
-                .parse()
-                .unwrap(),
         );
 
         let generator = network.configure_streaming(StreamFormat::AdcDacData);

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -95,7 +95,7 @@ pub struct Settings {
     ///
     /// # Value
     /// See [iir::IIR#miniconf]
-    #[tree]
+    #[tree(depth(2))]
     iir_ch: [[iir::IIR<f32>; IIR_CASCADE_LENGTH]; 2],
 
     /// Specified true if DI1 should be used as a "hold" input.
@@ -143,7 +143,7 @@ pub struct Settings {
     ///
     /// # Value
     /// See [signal_generator::BasicConfig#miniconf]
-    #[tree]
+    #[tree(depth(2))]
     signal_generator: [signal_generator::BasicConfig; 2],
 }
 
@@ -182,7 +182,7 @@ mod app {
 
     #[shared]
     struct Shared {
-        network: NetworkUsers<Settings, Telemetry, 2>,
+        network: NetworkUsers<Settings, Telemetry, 3>,
 
         settings: Settings,
         telemetry: TelemetryBuffer,
@@ -220,6 +220,7 @@ mod app {
             clock,
             env!("CARGO_BIN_NAME"),
             stabilizer.net.mac_address,
+            option_env!("BROKER").unwrap_or("10.34.16.10"),
         );
 
         let generator = network.configure_streaming(StreamFormat::AdcDacData);

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -260,7 +260,7 @@ mod app {
             clock,
             env!("CARGO_BIN_NAME"),
             stabilizer.net.mac_address,
-            option_env!("BROKER").unwrap_or("10.34.16.10"),
+            option_env!("BROKER").unwrap_or("mqtt"),
         );
 
         let generator = network.configure_streaming(StreamFormat::AdcDacData);

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -53,7 +53,7 @@ use stabilizer::{
     },
     net::{
         data_stream::{FrameGenerator, StreamFormat, StreamTarget},
-        miniconf::Miniconf,
+        miniconf::Tree,
         serde::{Deserialize, Serialize},
         telemetry::{Telemetry, TelemetryBuffer},
         NetworkState, NetworkUsers,
@@ -97,7 +97,7 @@ enum LockinMode {
     External,
 }
 
-#[derive(Copy, Clone, Debug, Miniconf)]
+#[derive(Copy, Clone, Debug, Tree)]
 pub struct Settings {
     /// Configure the Analog Front End (AFE) gain.
     ///
@@ -108,7 +108,7 @@ pub struct Settings {
     ///
     /// # Value
     /// Any of the variants of [Gain] enclosed in double quotes.
-    #[miniconf(defer)]
+    #[tree]
     afe: [Gain; 2],
 
     /// Specifies the operational mode of the lockin.
@@ -168,7 +168,7 @@ pub struct Settings {
     ///
     /// # Value
     /// One of the variants of [Conf] enclosed in double quotes.
-    #[miniconf(defer)]
+    #[tree]
     output_conf: [Conf; 2],
 
     /// Specifies the telemetry output period in seconds.
@@ -260,10 +260,6 @@ mod app {
             clock,
             env!("CARGO_BIN_NAME"),
             stabilizer.net.mac_address,
-            option_env!("BROKER")
-                .unwrap_or("10.34.16.1")
-                .parse()
-                .unwrap(),
         );
 
         let generator = network.configure_streaming(StreamFormat::AdcDacData);

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -260,6 +260,7 @@ mod app {
             clock,
             env!("CARGO_BIN_NAME"),
             stabilizer.net.mac_address,
+            option_env!("BROKER").unwrap_or("10.34.16.10"),
         );
 
         let generator = network.configure_streaming(StreamFormat::AdcDacData);

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -699,7 +699,7 @@ pub fn setup(
             sockets.add(smoltcp::socket::dhcpv4::Socket::new());
         }
 
-        sockets.add(smoltcp::socket::dns::Socket::new(&[], &mut store.dns_storage));
+        sockets.add(smoltcp::socket::dns::Socket::new(&[], &mut store.dns_storage[..]));
 
         for storage in store.udp_socket_storage[..].iter_mut() {
             let udp_socket = {

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -28,10 +28,12 @@ const NUM_SOCKETS: usize = NUM_UDP_SOCKETS + NUM_TCP_SOCKETS;
 pub struct NetStorage {
     pub ip_addrs: [smoltcp::wire::IpCidr; 1],
 
-    // Note: There is an additional socket set item required for the DHCP socket.
-    pub sockets: [smoltcp::iface::SocketStorage<'static>; NUM_SOCKETS + 1],
+    // Note: There is an additional socket set item required for the DHCP and DNS sockets
+    // respectively.
+    pub sockets: [smoltcp::iface::SocketStorage<'static>; NUM_SOCKETS + 2],
     pub tcp_socket_storage: [TcpSocketStorage; NUM_TCP_SOCKETS],
     pub udp_socket_storage: [UdpSocketStorage; NUM_UDP_SOCKETS],
+    pub dns_storage: [Option<smoltcp::socket::dns::DnsQuery>; 1],
 }
 
 #[derive(Copy, Clone)]
@@ -79,9 +81,10 @@ impl Default for NetStorage {
             ip_addrs: [smoltcp::wire::IpCidr::Ipv6(
                 smoltcp::wire::Ipv6Cidr::SOLICITED_NODE_PREFIX,
             )],
-            sockets: [smoltcp::iface::SocketStorage::EMPTY; NUM_SOCKETS + 1],
+            sockets: [smoltcp::iface::SocketStorage::EMPTY; NUM_SOCKETS + 2],
             tcp_socket_storage: [TcpSocketStorage::new(); NUM_TCP_SOCKETS],
             udp_socket_storage: [UdpSocketStorage::new(); NUM_UDP_SOCKETS],
+            dns_storage: [None; 1],
         }
     }
 }
@@ -695,6 +698,8 @@ pub fn setup(
         if ip_addrs.is_unspecified() {
             sockets.add(smoltcp::socket::dhcpv4::Socket::new());
         }
+
+        sockets.add(smoltcp::socket::dns::Socket::new(&[], &mut store.dns_storage));
 
         for storage in store.udp_socket_storage[..].iter_mut() {
             let udp_socket = {

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -699,7 +699,10 @@ pub fn setup(
             sockets.add(smoltcp::socket::dhcpv4::Socket::new());
         }
 
-        sockets.add(smoltcp::socket::dns::Socket::new(&[], &mut store.dns_storage[..]));
+        sockets.add(smoltcp::socket::dns::Socket::new(
+            &[],
+            &mut store.dns_storage[..],
+        ));
 
         for storage in store.udp_socket_storage[..].iter_mut() {
             let udp_socket = {

--- a/src/hardware/signal_generator.rs
+++ b/src/hardware/signal_generator.rs
@@ -1,3 +1,4 @@
+use miniconf::Tree;
 use rand_core::{RngCore, SeedableRng};
 use rand_xorshift::XorShiftRng;
 use serde::{Deserialize, Serialize};
@@ -19,7 +20,7 @@ pub enum Signal {
 /// Where `<signal>` may be any of [Signal] variants, `frequency` specifies the signal frequency
 /// in Hertz, `symmetry` specifies the normalized signal symmetry which ranges from 0 - 1.0, and
 /// `amplitude` specifies the signal amplitude in Volts.
-#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Tree)]
 pub struct BasicConfig {
     /// The signal type that should be generated. See [Signal] variants.
     pub signal: Signal,

--- a/src/hardware/signal_generator.rs
+++ b/src/hardware/signal_generator.rs
@@ -1,4 +1,3 @@
-use miniconf::Miniconf;
 use rand_core::{RngCore, SeedableRng};
 use rand_xorshift::XorShiftRng;
 use serde::{Deserialize, Serialize};
@@ -14,13 +13,13 @@ pub enum Signal {
 
 /// Basic configuration for a generated signal.
 ///
-/// # Miniconf
+/// # Miniconf Tree
 /// `{"signal": <signal>, "frequency", 1000.0, "symmetry": 0.5, "amplitude": 1.0}`
 ///
 /// Where `<signal>` may be any of [Signal] variants, `frequency` specifies the signal frequency
 /// in Hertz, `symmetry` specifies the normalized signal symmetry which ranges from 0 - 1.0, and
 /// `amplitude` specifies the signal amplitude in Volts.
-#[derive(Copy, Clone, Debug, Miniconf)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 pub struct BasicConfig {
     /// The signal type that should be generated. See [Signal] variants.
     pub signal: Signal,

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -110,7 +110,7 @@ where
             stack_manager.acquire_stack(),
             &get_client_id(app, "settings", mac),
             &prefix,
-            broker,
+            "10.35.20.1".parse().unwrap(),
             clock,
             S::default(),
         )
@@ -121,7 +121,7 @@ where
                 .unwrap();
 
         let mqtt = minimq::Minimq::new(
-            broker,
+            minimq::broker::NamedBroker::new("mqtt", stack_manager.acquire_stack()),
             &get_client_id(app, "tlm", mac),
             stack_manager.acquire_stack(),
             clock,

--- a/src/net/telemetry.rs
+++ b/src/net/telemetry.rs
@@ -129,7 +129,7 @@ impl<T: Serialize> TelemetryClient<T> {
         self.mqtt
             .client()
             .publish(
-                minimq::Publication::new(&telemetry)
+                minimq::Publication::<&[u8]>::new(&telemetry)
                     .topic(&self.telemetry_topic)
                     .finish()
                     .unwrap(),

--- a/src/net/telemetry.rs
+++ b/src/net/telemetry.rs
@@ -15,11 +15,10 @@ use serde::Serialize;
 
 use super::NetworkReference;
 use crate::hardware::{adc::AdcCode, afe::Gain, dac::DacCode, SystemTimer};
-use minimq::embedded_nal::IpAddr;
 
 /// The telemetry client for reporting telemetry data over MQTT.
 pub struct TelemetryClient<T: Serialize> {
-    mqtt: minimq::Minimq<'static, NetworkReference, SystemTimer>,
+    mqtt: minimq::Minimq<'static, NetworkReference, SystemTimer, minimq::broker::NamedBroker<NetworkReference>>,
     telemetry_topic: String<128>,
     _telemetry: core::marker::PhantomData<T>,
 }
@@ -103,7 +102,7 @@ impl<T: Serialize> TelemetryClient<T> {
     /// # Returns
     /// A new telemetry client.
     pub fn new(
-        mqtt: minimq::Minimq<'static, NetworkReference, SystemTimer>,
+        mqtt: minimq::Minimq<'static, NetworkReference, SystemTimer, minimq::broker::NamedBroker<NetworkReference>>,
         prefix: &str,
     ) -> Self {
         let mut telemetry_topic: String<128> = String::from(prefix);

--- a/src/net/telemetry.rs
+++ b/src/net/telemetry.rs
@@ -18,7 +18,12 @@ use crate::hardware::{adc::AdcCode, afe::Gain, dac::DacCode, SystemTimer};
 
 /// The telemetry client for reporting telemetry data over MQTT.
 pub struct TelemetryClient<T: Serialize> {
-    mqtt: minimq::Minimq<'static, NetworkReference, SystemTimer, minimq::broker::NamedBroker<NetworkReference>>,
+    mqtt: minimq::Minimq<
+        'static,
+        NetworkReference,
+        SystemTimer,
+        minimq::broker::NamedBroker<NetworkReference>,
+    >,
     telemetry_topic: String<128>,
     _telemetry: core::marker::PhantomData<T>,
 }
@@ -102,7 +107,12 @@ impl<T: Serialize> TelemetryClient<T> {
     /// # Returns
     /// A new telemetry client.
     pub fn new(
-        mqtt: minimq::Minimq<'static, NetworkReference, SystemTimer, minimq::broker::NamedBroker<NetworkReference>>,
+        mqtt: minimq::Minimq<
+            'static,
+            NetworkReference,
+            SystemTimer,
+            minimq::broker::NamedBroker<NetworkReference>,
+        >,
         prefix: &str,
     ) -> Self {
         let mut telemetry_topic: String<128> = String::from(prefix);


### PR DESCRIPTION
Adds support for using DNS-specified brokers. This PR also updates the minimq clients for the `settings` and `telemetry` users. We should probably wait until minimq and miniconf get released.