### PR TITLE
Tuning RX buffer, updating HITL script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * `idsp` crate update to 0.10: `lockin` now uses a double second order lowpass.
 * The `batch_size` field in the the UDP stream frame now contains the number of batches
   not the number of samples per batch. It has been renamed to `batches`.
+ * All MQTT clients upgraded and APIs updated.
+ * MQTT broker may now be specified via DNS hostnames
 
 ## [v0.8.1](https://github.com/quartiq/stabilizer/compare/v0.8.0...v0.8.1) - 2022-11-14)
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -28,14 +28,14 @@ pub type NetworkReference =
     smoltcp_nal::shared::NetworkStackProxy<'static, NetworkStack>;
 
 pub struct MqttStorage {
-    telemetry: [u8; 1024],
+    telemetry: [u8; 2048],
     settings: [u8; 1024],
 }
 
 impl Default for MqttStorage {
     fn default() -> Self {
         Self {
-            telemetry: [0u8; 1024],
+            telemetry: [0u8; 2048],
             settings: [0u8; 1024],
         }
     }
@@ -138,6 +138,9 @@ where
             stack_manager.acquire_stack(),
             clock,
             minimq::ConfigBuilder::new(named_broker, &mut store.telemetry)
+                // The telemetry client doesn't receive any messages except MQTT control packets.
+                // As such, we don't need much of the buffer for RX.
+                .rx_buffer(minimq::config::BufferConfig::Maximum(100))
                 .client_id(&get_client_id(app, "tlm", mac))
                 .unwrap(),
         );


### PR DESCRIPTION
Tunes the RX buffer of the telemetry client to only need 100 bytes, which reserves much more data for TX (i.e. large telemetry payloads). Also increasing the buffer to 2KB, should have very sufficient telemetry buffers now.

I also updated the `loopback.py` to use auto-discovery to make it easier to run