### PR TITLE
Adding support for multicast stream data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   not the number of samples per batch. It has been renamed to `batches`.
  * All MQTT clients upgraded and APIs updated.
  * MQTT broker may now be specified via DNS hostnames
+ * `hitl/streaming.py` no longer requires a prefix
+ * Streaming now supports UDP multicast addresses
 
 ## [v0.8.1](https://github.com/quartiq/stabilizer/compare/v0.8.0...v0.8.1) - 2022-11-14)
 

--- a/hitl/streaming.py
+++ b/hitl/streaming.py
@@ -6,7 +6,7 @@ import logging
 import ipaddress
 import argparse
 
-from miniconf import Miniconf
+import miniconf
 from stabilizer.stream import measure, StabilizerStream, get_local_ip
 
 logger = logging.getLogger(__name__)
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 async def _main():
     parser = argparse.ArgumentParser(description="Stabilizer Stream HITL test")
-    parser.add_argument("prefix", type=str,
+    parser.add_argument("prefix", type=str, nargs='?',
                         help="The MQTT topic prefix of the target")
     parser.add_argument("--broker", "-b", default="mqtt", type=str,
                         help="The MQTT broker address")
@@ -28,9 +28,19 @@ async def _main():
                         help="Maximum loss for success")
     args = parser.parse_args()
 
+    prefix = args.prefix
+    if not args.prefix:
+        devices = await miniconf.discover(args.broker, 'dt/sinara/dual-iir/+', 1)
+        if not devices:
+            raise Exception('No Stabilizer (Dual-iir) devices found')
+        assert len(devices) == 1, \
+            f'Multiple Stabilizers found: {devices}. Please specify one with --prefix'
+
+        prefix = devices.pop()
+
     logging.basicConfig(level=logging.INFO)
 
-    conf = await Miniconf.create(args.prefix, args.broker)
+    conf = await miniconf.Miniconf.create(prefix, args.broker)
 
     stream_target = [int(x) for x in args.ip.split('.')]
     if ipaddress.ip_address(args.ip).is_unspecified:

--- a/hitl/streaming.py
+++ b/hitl/streaming.py
@@ -19,7 +19,7 @@ async def _main():
     parser.add_argument("--broker", "-b", default="mqtt", type=str,
                         help="The MQTT broker address")
     parser.add_argument("--ip", default="0.0.0.0",
-                        help="The address to use for streaming")
+                        help="The IP address to listen on")
     parser.add_argument("--port", type=int, default=9293,
                         help="Local port to listen on")
     parser.add_argument("--duration", type=float, default=10.,

--- a/py/stabilizer/stream.py
+++ b/py/stabilizer/stream.py
@@ -195,7 +195,7 @@ async def main():
 
     logging.basicConfig(level=logging.INFO)
     _transport, stream = await StabilizerStream.open(
-        (args.host, args.port), args.broker, args.maxsize)
+        args.host, args.port, args.broker, args.maxsize)
     await measure(stream, args.duration)
 
 

--- a/py/stabilizer/stream.py
+++ b/py/stabilizer/stream.py
@@ -109,8 +109,9 @@ class StabilizerStream(asyncio.DatagramProtocol):
             group = socket.inet_aton(addr)
             iface = socket.inet_aton('.'.join([str(x) for x in get_local_ip(broker)]))
             sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, group + iface)
-
-        sock.bind(('', port))
+            sock.bind(('', port))
+        else:
+            sock.bind((addr, port))
 
         transport, protocol = await loop.create_datagram_endpoint(lambda: cls(maxsize), sock=sock)
         return transport, protocol


### PR DESCRIPTION
This PR fixes #786 by updating the python tools to direct Stabilizer to stream to multicast UDP addresses. Note that there is no firmware change required for this.

Local run of the streaming HITL:
```
$ python311 hitl/streaming.py --broker 10.35.20.1 dt/sinara/dual-iir/04-91-62-d2-a8-6f
INFO:gmqtt.mqtt.protocol:[CONNECTION MADE]
INFO:gmqtt.mqtt.package:[SEND SUB] 1 [b'dt/sinara/dual-iir/04-91-62-d2-a8-6f/response']
INFO:gmqtt.mqtt.package:[SEND SUB] 2 [b'dt/sinara/dual-iir/04-91-62-d2-a8-6f/settings/#']
INFO:gmqtt.mqtt.handler:[SUBACK] 1 (0,)
INFO:miniconf.miniconf:Handling subscription for 1
INFO:gmqtt.mqtt.handler:[SUBACK] 2 (0,)
INFO:miniconf.miniconf:Handling subscription for 2
INFO:__main__:Starting stream
INFO:miniconf.miniconf:Sending "{'ip': [239, 192, 1, 100], 'port': 9293}" to "dt/sinara/dual-iir/04-91-62-d2-a8-6f/settings/stream_target" with CD: b'9ea73129681e11ee979b60f262b6eb3e'
INFO:__main__:Testing stream reception
INFO:stabilizer.stream:Connection made (listening)
INFO:stabilizer.stream:Received 59.9231 MB, 5.99231 MB/s
INFO:stabilizer.stream:Loss: 38918/975216 batches (3.99071 %)
INFO:__main__:Stopping stream
INFO:miniconf.miniconf:Sending "{'ip': [0, 0, 0, 0], 'port': 0}" to "dt/sinara/dual-iir/04-91-62-d2-a8-6f/settings/stream_target" with CD: b'a49b9329681e11ee92d760f262b6eb3e'
INFO:__main__:Draining queue
INFO:__main__:Verifying no further frames are received
PASS
```