### PR TITLE
Adding basic USB implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
+name = "bbqueue"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3baa8859d1a4c7411039a75c0599a4640ef1c9a8fc811e4325b00e6cfe0a55"
+
+[[package]]
 name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,6 +896,7 @@ name = "stabilizer"
 version = "0.8.1"
 dependencies = [
  "ad9959",
+ "bbqueue",
  "cortex-m 0.7.7",
  "cortex-m-rt",
  "cortex-m-rtic",
@@ -918,6 +925,8 @@ dependencies = [
  "spin",
  "stm32h7xx-hal",
  "systick-monotonic",
+ "usb-device",
+ "usbd-serial",
 ]
 
 [[package]]
@@ -954,6 +963,7 @@ dependencies = [
  "paste",
  "smoltcp",
  "stm32h7",
+ "synopsys-usb-otg",
  "void",
 ]
 
@@ -977,6 +987,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synopsys-usb-otg"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678f3707a7b1fd4863023292c42f73c6bab0e9b0096f41ae612d1af0ff221b45"
+dependencies = [
+ "cortex-m 0.7.7",
+ "embedded-hal",
+ "usb-device",
+ "vcell",
 ]
 
 [[package]]
@@ -1007,6 +1029,23 @@ name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "usb-device"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
+
+[[package]]
+name = "usbd-serial"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db75519b86287f12dcf0d171c7cf4ecc839149fe9f3b720ac4cfce52959e1dfe"
+dependencies = [
+ "embedded-hal",
+ "nb 0.1.3",
+ "usb-device",
+]
 
 [[package]]
 name = "varint-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,8 +1033,7 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 [[package]]
 name = "usb-device"
 version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
+source = "git+https://github.com/ryan-summers/usb-device?branch=rs/issue-128-v0.2.9#59a02aaedd385d29d896f07fe977bff1f8963eb2"
 
 [[package]]
 name = "usbd-serial"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,13 +60,16 @@ enum-iterator = "1.4.1"
 rand_xorshift = "0.3.0"
 rand_core = "0.6.4"
 minimq = { git = "https://github.com/quartiq/minimq" } # "0.8"
+usb-device = "0.2.9"
+usbd-serial = "0.1.1"
 # Keep this synced with the miniconf version in py/setup.py
 miniconf = { git = "https://github.com/quartiq/miniconf.git" } # "0.9"
 smoltcp-nal = { version = "0.4.1", features = ["shared-stack"]}
+bbqueue = "0.5"
 
 [dependencies.stm32h7xx-hal]
 git = "https://github.com/stm32-rs/stm32h7xx-hal"
-features = ["stm32h743v", "rt", "ethernet", "xspi"]
+features = ["stm32h743v", "rt", "ethernet", "xspi", "usb_hs"]
 
 [features]
 nightly = [ ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,10 @@ bbqueue = "0.5"
 git = "https://github.com/stm32-rs/stm32h7xx-hal"
 features = ["stm32h743v", "rt", "ethernet", "xspi", "usb_hs"]
 
+[patch.crates-io.usb-device]
+git = "https://github.com/ryan-summers/usb-device"
+branch = "rs/issue-128-v0.2.9"
+
 [features]
 nightly = [ ]
 pounder_v1_0 = [ ]

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -40,11 +40,11 @@ use idsp::iir;
 use stabilizer::{
     hardware::{
         self,
-        serial_terminal::SerialTerminal,
         adc::{Adc0Input, Adc1Input, AdcCode},
         afe::Gain,
         dac::{Dac0Output, Dac1Output, DacCode},
         hal,
+        serial_terminal::SerialTerminal,
         signal_generator::{self, SignalGenerator},
         timers::SamplingTimer,
         DigitalInput0, DigitalInput1, SystemTimer, Systick, AFE0, AFE1,
@@ -183,6 +183,7 @@ mod app {
 
     #[shared]
     struct Shared {
+        usb_terminal: SerialTerminal,
         network: NetworkUsers<Settings, Telemetry, 3>,
 
         settings: Settings,
@@ -192,7 +193,6 @@ mod app {
 
     #[local]
     struct Local {
-        usb_terminal: SerialTerminal,
         sampling_timer: SamplingTimer,
         digital_inputs: (DigitalInput0, DigitalInput1),
         afes: (AFE0, AFE1),
@@ -230,6 +230,7 @@ mod app {
         let settings = Settings::default();
 
         let shared = Shared {
+            usb_terminal: stabilizer.usb_serial,
             network,
             settings,
             telemetry: TelemetryBuffer::default(),
@@ -248,7 +249,6 @@ mod app {
         };
 
         let mut local = Local {
-            usb_terminal: stabilizer.usb_serial,
             sampling_timer: stabilizer.adc_dac_timer,
             digital_inputs: stabilizer.digital_inputs,
             afes: stabilizer.afes,
@@ -392,7 +392,7 @@ mod app {
         );
     }
 
-    #[idle(shared=[network])]
+    #[idle(shared=[network, usb_terminal])]
     fn idle(mut c: idle::Context) -> ! {
         loop {
             match c.shared.network.lock(|net| net.update()) {
@@ -400,7 +400,15 @@ mod app {
                     settings_update::spawn().unwrap()
                 }
                 NetworkState::Updated => {}
-                NetworkState::NoChange => cortex_m::asm::wfi(),
+                NetworkState::NoChange => {
+                    // We can't sleep if USB is not in suspend.
+                    if c.shared
+                        .usb_terminal
+                        .lock(|terminal| terminal.usb_is_suspended())
+                    {
+                        cortex_m::asm::wfi();
+                    }
+                }
             }
         }
     }
@@ -456,12 +464,12 @@ mod app {
             .unwrap();
     }
 
-    #[task(priority = 1, local=[usb_terminal])]
-    fn usb(c: usb::Context) {
+    #[task(priority = 1, shared=[usb_terminal])]
+    fn usb(mut c: usb::Context) {
         // Handle the USB serial terminal.
-        c.local.usb_terminal.process();
+        c.shared.usb_terminal.lock(|usb| usb.process());
 
-        // Schedule to run this task every 10ms.
+        // Schedule to run this task every 10 milliseconds.
         usb::spawn_after(10u64.millis()).unwrap();
     }
 

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -11,6 +11,7 @@ pub mod delay;
 pub mod design_parameters;
 pub mod input_stamper;
 pub mod pounder;
+pub mod serial_terminal;
 pub mod setup;
 pub mod shared_adc;
 pub mod signal_generator;
@@ -29,6 +30,8 @@ pub type AFE1 = afe::ProgrammableGainAmplifier<
     hal::gpio::gpiod::PD14<hal::gpio::Output<hal::gpio::PushPull>>,
     hal::gpio::gpiod::PD15<hal::gpio::Output<hal::gpio::PushPull>>,
 >;
+
+pub type UsbBus = stm32h7xx_hal::usb_hs::UsbBus<stm32h7xx_hal::usb_hs::USB2>;
 
 // Type alias for digital input 0 (DI0).
 pub type DigitalInput0 = hal::gpio::gpiog::PG9<hal::gpio::Input>;

--- a/src/hardware/serial_terminal.rs
+++ b/src/hardware/serial_terminal.rs
@@ -12,7 +12,8 @@ impl Write for OutputBuffer {
         let data = s.as_bytes();
 
         // Write as much data as possible to the output buffer.
-        let Ok(mut grant) = self.producer.grant_max_remaining(data.len()) else {
+        let Ok(mut grant) = self.producer.grant_max_remaining(data.len())
+        else {
             // Output buffer is full, silently drop the data.
             return Ok(());
         };

--- a/src/hardware/serial_terminal.rs
+++ b/src/hardware/serial_terminal.rs
@@ -1,0 +1,71 @@
+use super::UsbBus;
+
+static OUTPUT_BUFFER: bbqueue::BBBuffer<1024> = bbqueue::BBBuffer::new();
+
+pub struct SerialTerminal {
+    usb_device: usb_device::device::UsbDevice<'static, UsbBus>,
+    usb_serial: usbd_serial::SerialPort<'static, UsbBus>,
+    output: bbqueue::Consumer<'static, 1024>,
+}
+
+impl SerialTerminal {
+    pub fn new(
+        usb_device: usb_device::device::UsbDevice<'static, UsbBus>,
+        usb_serial: usbd_serial::SerialPort<'static, UsbBus>,
+    ) -> Self {
+        let (_producer, consumer) = OUTPUT_BUFFER.try_split().unwrap();
+
+        Self {
+            usb_device,
+            usb_serial,
+            output: consumer,
+        }
+    }
+
+    fn flush(&mut self) {
+        let read = match self.output.read() {
+            Ok(grant) => grant,
+            Err(bbqueue::Error::InsufficientSize) => return,
+            err => err.unwrap(),
+        };
+
+        match self.usb_serial.write(read.buf()) {
+            Ok(count) => read.release(count),
+            Err(usbd_serial::UsbError::WouldBlock) => read.release(0),
+            Err(_) => {
+                let len = read.buf().len();
+                read.release(len);
+            }
+        }
+    }
+
+    pub fn process(&mut self) {
+        self.flush();
+
+        if !self.usb_device.poll(&mut [&mut self.usb_serial]) {
+            return;
+        }
+
+        let mut buffer = [0u8; 64];
+        match self.usb_serial.read(&mut buffer) {
+            Ok(count) => {
+                for &value in &buffer[..count] {
+                    // Currently, just echo it back.
+                    self.usb_serial.write(&[value]).ok();
+                }
+            }
+
+            Err(usbd_serial::UsbError::WouldBlock) => {}
+            Err(_) => {
+                // Flush the output buffer if USB is not connected.
+                self.output
+                    .read()
+                    .map(|grant| {
+                        let len = grant.buf().len();
+                        grant.release(len);
+                    })
+                    .ok();
+            }
+        }
+    }
+}

--- a/src/hardware/serial_terminal.rs
+++ b/src/hardware/serial_terminal.rs
@@ -39,6 +39,10 @@ impl SerialTerminal {
         }
     }
 
+    pub fn usb_is_suspended(&self) -> bool {
+        self.usb_device.state() == usb_device::device::UsbDeviceState::Suspend
+    }
+
     pub fn process(&mut self) {
         self.flush();
 
@@ -51,7 +55,9 @@ impl SerialTerminal {
             Ok(count) => {
                 for &value in &buffer[..count] {
                     // Currently, just echo it back.
+                    self.usb_serial.write(b"echo: ").ok();
                     self.usb_serial.write(&[value]).ok();
+                    self.usb_serial.write(b"\n\r").ok();
                 }
             }
 

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -1030,10 +1030,10 @@ pub fn setup(
 
         // Generate a device serial number from the MAC address.
         let serial_number =
-            cortex_m::singleton!(: Option<heapless::String<64>> = None)
+            cortex_m::singleton!(: Option<heapless::String<17>> = None)
                 .unwrap();
         {
-            let mut serial_string: heapless::String<64> =
+            let mut serial_string: heapless::String<17> =
                 heapless::String::new();
             let octets = mac_addr.0;
 

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -15,10 +15,10 @@ use smoltcp_nal::smoltcp;
 use super::{
     adc, afe, cpu_temp_sensor::CpuTempSensor, dac, delay, design_parameters,
     eeprom, input_stamper::InputStamper, pounder,
-    pounder::dds_output::DdsOutput, shared_adc::SharedAdc, timers,
-    DigitalInput0, DigitalInput1, EemDigitalInput0, EemDigitalInput1,
-    EemDigitalOutput0, EemDigitalOutput1, EthernetPhy, NetworkStack,
-    SystemTimer, Systick, UsbBus, AFE0, AFE1, serial_terminal::SerialTerminal,
+    pounder::dds_output::DdsOutput, serial_terminal::SerialTerminal,
+    shared_adc::SharedAdc, timers, DigitalInput0, DigitalInput1,
+    EemDigitalInput0, EemDigitalInput1, EemDigitalOutput0, EemDigitalOutput1,
+    EthernetPhy, NetworkStack, SystemTimer, Systick, UsbBus, AFE0, AFE1,
 };
 
 const NUM_TCP_SOCKETS: usize = 4;
@@ -1033,7 +1033,8 @@ pub fn setup(
             cortex_m::singleton!(: Option<heapless::String<64>> = None)
                 .unwrap();
         {
-            let mut serial_string: heapless::String<64> = heapless::String::new();
+            let mut serial_string: heapless::String<64> =
+                heapless::String::new();
             let octets = mac_addr.0;
 
             write!(


### PR DESCRIPTION
Adding a PR for basic USB terminal support.

For some reason, this isn't working yet on Windows (descriptor rquests are failing and windows can't recognize the device).

I suspect something's going wrong in the configuration of the peripheral and am still investigating.

Current USB interface is an echo chamber:
```
PS C:\Users\rsummers> python -m serial COM22
--- Miniterm on COM22  9600,8,N,1 ---
--- Quit: Ctrl+] | Menu: Ctrl+T | Help: Ctrl+T followed by Ctrl+H ---
echo: a
echo: s
echo: d
echo: f
echo: s
echo: a
echo: s
echo: d
echo: f
echo: s
echo: a
```