### PR TITLE
bump deps and release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased](https://github.com/quartiq/stabilizer/compare/v0.8.1...main)
+## [0.9.0](https://github.com/quartiq/stabilizer/compare/v0.8.1...v0.9.0)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,12 +711,12 @@ dependencies = [
 
 [[package]]
 name = "rtt-logger"
-version = "0.3.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7352ea2ea8c477bc6286674554dbb3487ec70472188f0939f0868f6e84921fd7"
+checksum = "b2f42c228caf6eab0fe8374ef3988b9db07dbe0b12b65b4a02aaacb48b03354e"
 dependencies = [
  "log",
- "rtt-target 0.4.0",
+ "rtt-target",
 ]
 
 [[package]]
@@ -725,16 +725,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065d6058bb1204f51a562a67209e1817cf714759d5cf845aa45c75fa7b0b9d9b"
 dependencies = [
- "ufmt-write",
-]
-
-[[package]]
-name = "rtt-target"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afa12c77ba1b9bf560e4039a9b9a08bb9cde0e9e6923955eeb917dd8d5cf303"
-dependencies = [
- "critical-section",
+ "cortex-m 0.7.7",
  "ufmt-write",
 ]
 
@@ -926,7 +917,7 @@ dependencies = [
  "rand_core",
  "rand_xorshift",
  "rtt-logger",
- "rtt-target 0.3.1",
+ "rtt-target",
  "serde",
  "serde-json-core",
  "shared-bus 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -593,11 +593,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70bf6736f74634d299d00086f02986875b3c2d924781a6a2cb6c201e73da0ceb"
+checksum = "683751d591e6d81200c39fb0d1032608b77724f34114db54f571ff1317b337c0"
 dependencies = [
- "num_enum_derive 0.7.0",
+ "num_enum_derive 0.7.1",
 ]
 
 [[package]]
@@ -613,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
+checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -711,12 +711,12 @@ dependencies = [
 
 [[package]]
 name = "rtt-logger"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f42c228caf6eab0fe8374ef3988b9db07dbe0b12b65b4a02aaacb48b03354e"
+checksum = "7352ea2ea8c477bc6286674554dbb3487ec70472188f0939f0868f6e84921fd7"
 dependencies = [
  "log",
- "rtt-target",
+ "rtt-target 0.4.0",
 ]
 
 [[package]]
@@ -725,7 +725,16 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065d6058bb1204f51a562a67209e1817cf714759d5cf845aa45c75fa7b0b9d9b"
 dependencies = [
- "cortex-m 0.7.7",
+ "ufmt-write",
+]
+
+[[package]]
+name = "rtt-target"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3afa12c77ba1b9bf560e4039a9b9a08bb9cde0e9e6923955eeb917dd8d5cf303"
+dependencies = [
+ "critical-section",
  "ufmt-write",
 ]
 
@@ -782,9 +791,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.189"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
+checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
 dependencies = [
  "serde_derive",
 ]
@@ -802,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.189"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
+checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -912,12 +921,12 @@ dependencies = [
  "minimq",
  "mono-clock",
  "mutex-trait",
- "num_enum 0.7.0",
+ "num_enum 0.7.1",
  "paste",
  "rand_core",
  "rand_xorshift",
  "rtt-logger",
- "rtt-target",
+ "rtt-target 0.3.1",
  "serde",
  "serde-json-core",
  "shared-bus 0.3.0",
@@ -1034,7 +1043,8 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 [[package]]
 name = "usb-device"
 version = "0.2.9"
-source = "git+https://github.com/ryan-summers/usb-device?branch=rs/issue-128-v0.2.9#59a02aaedd385d29d896f07fe977bff1f8963eb2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
 
 [[package]]
 name = "usbd-serial"
@@ -1073,9 +1083,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "volatile-register"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
+checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "shared-bus"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb5650c146f3186332c5da30ff542f7d1ff0c2410346cd861f34fa836dc0d84"
+checksum = "c6b8d3f0e34309c22ca4a9a27d24fa493e31573485f3493802b75b9d706756a6"
 dependencies = [
  "atomic-polyfill 1.0.3",
  "cortex-m 0.7.7",
@@ -923,7 +923,7 @@ dependencies = [
  "rtt-target",
  "serde",
  "serde-json-core",
- "shared-bus 0.3.0",
+ "shared-bus 0.3.1",
  "smoltcp-nal",
  "spin",
  "stm32h7xx-hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "ad9959"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bit_field",
  "bitflags 2.4.1",
@@ -427,8 +427,9 @@ dependencies = [
 
 [[package]]
 name = "miniconf"
-version = "0.8.0"
-source = "git+https://github.com/quartiq/miniconf.git?branch=rj/bump-deps#0755211c60ec2da6b349e65ec6572ca6ef6058a1"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df2d7bdba3acb28460c347b21e1e88d869f2716ebe060eb6a79f7b76b57de72"
 dependencies = [
  "embedded-io",
  "heapless",
@@ -443,8 +444,9 @@ dependencies = [
 
 [[package]]
 name = "miniconf_derive"
-version = "0.8.0"
-source = "git+https://github.com/quartiq/miniconf.git?branch=rj/bump-deps#0755211c60ec2da6b349e65ec6572ca6ef6058a1"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f46d25f40e41f552d76b8eb9e225fe493ebf978a5c3f42b7599e45cfe6b4e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -453,8 +455,9 @@ dependencies = [
 
 [[package]]
 name = "minimq"
-version = "0.7.0"
-source = "git+https://github.com/quartiq/minimq?branch=rj/std-embedded-nal-0.2#07ebfc1d36ccd7662fc405f805cc18d2625e8c41"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b561c2c86a3509f7c514f546fb24755753a30fdcf67cce8d5f2f38688483cd31"
 dependencies = [
  "bit_field",
  "embedded-nal",
@@ -893,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "stabilizer"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "ad9959",
  "bbqueue",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "embedded-io"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bbadc628dc286b9ae02f0cb0f5411c056eb7487b72f0083203f115de94060"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "embedded-nal"
@@ -428,7 +428,7 @@ dependencies = [
 [[package]]
 name = "miniconf"
 version = "0.8.0"
-source = "git+https://github.com/quartiq/miniconf.git#587a5bf6f498a9bd05d4e6fb76e7b108dd0f9a1d"
+source = "git+https://github.com/quartiq/miniconf.git?branch=rj/bump-deps#0755211c60ec2da6b349e65ec6572ca6ef6058a1"
 dependencies = [
  "embedded-io",
  "heapless",
@@ -444,7 +444,7 @@ dependencies = [
 [[package]]
 name = "miniconf_derive"
 version = "0.8.0"
-source = "git+https://github.com/quartiq/miniconf.git#587a5bf6f498a9bd05d4e6fb76e7b108dd0f9a1d"
+source = "git+https://github.com/quartiq/miniconf.git?branch=rj/bump-deps#0755211c60ec2da6b349e65ec6572ca6ef6058a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -454,13 +454,13 @@ dependencies = [
 [[package]]
 name = "minimq"
 version = "0.7.0"
-source = "git+https://github.com/quartiq/minimq#cec9ce70a9091b4e20d3b09c0efe8341dc762f41"
+source = "git+https://github.com/quartiq/minimq?branch=rj/std-embedded-nal-0.2#07ebfc1d36ccd7662fc405f805cc18d2625e8c41"
 dependencies = [
  "bit_field",
  "embedded-nal",
  "embedded-time",
  "heapless",
- "num_enum 0.5.11",
+ "num_enum 0.7.1",
  "serde",
  "smlang",
  "varint-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ default-target = "thumbv7em-none-eabihf"
 members = ["ad9959"]
 
 [dependencies]
-cortex-m = { version = "0.7.7", features = ["inline-asm"] }
+cortex-m = { version = "0.7.7", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = { version = "0.7", features = ["device"] }
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"] }
-rtt-target = { version = "0.3", features = ["cortex-m"] }
+rtt-target = "0.3"
 serde = { version = "1.0", features = ["derive"], default-features = false }
 serde-json-core = "0.5"
 heapless = { version = "0.7.16", features = ["serde"] }
@@ -50,7 +50,7 @@ ad9959 = { path = "ad9959", version = "0.2.0" }
 mcp230xx = "1.0"
 mutex-trait = "0.2"
 fugit = "0.3"
-rtt-logger = "0.2"
+rtt-logger = "0.3"
 systick-monotonic = "1.0"
 mono-clock = "0.1"
 spin = { version = "0.9", default-features = false, features = ["spin_mutex"]}
@@ -60,6 +60,7 @@ enum-iterator = "1.4.1"
 rand_xorshift = "0.3.0"
 rand_core = "0.6.4"
 minimq = { git = "https://github.com/quartiq/minimq" } # "0.8"
+# patch with https://github.com/rust-embedded-community/usb-device/pull/129
 usb-device = "0.2.9"
 usbd-serial = "0.1.1"
 # Keep this synced with the miniconf version in py/setup.py
@@ -70,10 +71,6 @@ bbqueue = "0.5"
 [dependencies.stm32h7xx-hal]
 version = "0.15.0"
 features = ["stm32h743v", "rt", "ethernet", "xspi", "usb_hs"]
-
-[patch.crates-io.usb-device]
-git = "https://github.com/ryan-summers/usb-device"
-branch = "rs/issue-128-v0.2.9"
 
 [features]
 nightly = [ ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ embedded-hal = "0.2.7"
 num_enum = { version = "0.7.0", default-features = false }
 paste = "1"
 idsp = "0.12"
-ad9959 = { path = "ad9959", version = "0.2.0" }
+ad9959 = { path = "ad9959", version = "0.2.1" }
 mcp230xx = "1.0"
 mutex-trait = "0.2"
 fugit = "0.3"
@@ -59,12 +59,12 @@ lm75 = "0.2"
 enum-iterator = "1.4.1"
 rand_xorshift = "0.3.0"
 rand_core = "0.6.4"
-minimq = { git = "https://github.com/quartiq/minimq", branch = "release-0.8.0", version = "0.8.0" } # "0.8"
+minimq = "0.8.0"
 # patch with https://github.com/rust-embedded-community/usb-device/pull/129
 usb-device = "0.2.9"
 usbd-serial = "0.1.1"
 # Keep this synced with the miniconf version in py/setup.py
-miniconf = { git = "https://github.com/quartiq/miniconf.git", branch = "rj/bump-deps", version = "0.9.0" } # "0.9"
+miniconf = "0.9.0"
 smoltcp-nal = { version = "0.4.1", features = ["shared-stack"]}
 bbqueue = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stabilizer"
 # Keep versions in Cargo.toml and py/setup.py synchronized.
-version = "0.8.1"
+version = "0.9.0"
 resolver = "2"
 authors = [
 	"Robert Jördens <rj@quartiq.de>",
@@ -59,12 +59,12 @@ lm75 = "0.2"
 enum-iterator = "1.4.1"
 rand_xorshift = "0.3.0"
 rand_core = "0.6.4"
-minimq = { git = "https://github.com/quartiq/minimq", branch = "rj/std-embedded-nal-0.2" } # "0.8"
+minimq = { git = "https://github.com/quartiq/minimq", branch = "release-0.8.0", version = "0.8.0" } # "0.8"
 # patch with https://github.com/rust-embedded-community/usb-device/pull/129
 usb-device = "0.2.9"
 usbd-serial = "0.1.1"
 # Keep this synced with the miniconf version in py/setup.py
-miniconf = { git = "https://github.com/quartiq/miniconf.git", branch = "rj/bump-deps" } # "0.9"
+miniconf = { git = "https://github.com/quartiq/miniconf.git", branch = "rj/bump-deps", version = "0.9.0" } # "0.9"
 smoltcp-nal = { version = "0.4.1", features = ["shared-stack"]}
 bbqueue = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,12 +59,12 @@ lm75 = "0.2"
 enum-iterator = "1.4.1"
 rand_xorshift = "0.3.0"
 rand_core = "0.6.4"
-minimq = { git = "https://github.com/quartiq/minimq" } # "0.8"
+minimq = { git = "https://github.com/quartiq/minimq", branch = "rj/std-embedded-nal-0.2" } # "0.8"
 # patch with https://github.com/rust-embedded-community/usb-device/pull/129
 usb-device = "0.2.9"
 usbd-serial = "0.1.1"
 # Keep this synced with the miniconf version in py/setup.py
-miniconf = { git = "https://github.com/quartiq/miniconf.git" } # "0.9"
+miniconf = { git = "https://github.com/quartiq/miniconf.git", branch = "rj/bump-deps" } # "0.9"
 smoltcp-nal = { version = "0.4.1", features = ["shared-stack"]}
 bbqueue = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ ad9959 = { path = "ad9959", version = "0.2.0" }
 mcp230xx = "1.0"
 mutex-trait = "0.2"
 fugit = "0.3"
-rtt-logger = "0.3"
+rtt-logger = "0.2"
 systick-monotonic = "1.0"
 mono-clock = "0.1"
 spin = { version = "0.9", default-features = false, features = ["spin_mutex"]}

--- a/ad9959/Cargo.toml
+++ b/ad9959/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ad9959"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Ryan Summers <ryan.summers@vertigo-designs.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/py/setup.py
+++ b/py/setup.py
@@ -15,6 +15,6 @@ setup(
         "matplotlib",
         "gmqtt",
         # Keep this synced with the miniconf version in Cargo.toml
-        "miniconf-mqtt@git+https://github.com/quartiq/miniconf@0.8.0#subdirectory=py/miniconf-mqtt",
+        "miniconf-mqtt@git+https://github.com/quartiq/miniconf@v0.9.0#subdirectory=py/miniconf-mqtt",
     ],
 )

--- a/py/setup.py
+++ b/py/setup.py
@@ -15,6 +15,6 @@ setup(
         "matplotlib",
         "gmqtt",
         # Keep this synced with the miniconf version in Cargo.toml
-        "miniconf-mqtt@git+https://github.com/quartiq/miniconf@main#subdirectory=py/miniconf-mqtt",
+        "miniconf-mqtt@git+https://github.com/quartiq/miniconf@0.8.0#subdirectory=py/miniconf-mqtt",
     ],
 )

--- a/src/net/data_stream.rs
+++ b/src/net/data_stream.rs
@@ -46,8 +46,8 @@ const FRAME_COUNT: usize = 4;
 
 // The size of each frame in bytes.
 // Ensure the resulting ethernet frame is within the MTU:
-// 1500 MTU - 40 IP6 header - 20 UDP header
-const FRAME_SIZE: usize = 1500 - 40 - 20;
+// 1500 MTU - 40 IP6 header - 8 UDP header
+const FRAME_SIZE: usize = 1500 - 40 - 8;
 
 // The size of the frame queue must be at least as large as the number of frame buffers. Every
 // allocated frame buffer should fit in the queue.


### PR DESCRIPTION
- also sneak in: "stream: udp header is 8 byte"
- bump dependencies
- [x] waiting for https://github.com/quartiq/miniconf/pull/184 release
- [x] waiting for https://github.com/quartiq/minimq/pull/153 release
- removed usb-device patch as that can also be done in a semver compat update later. it's also windows-specific (IIRC).
- release 0.9.0 chores
