### PR TITLE
Adding initial support for configuring parameters via USB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,12 +22,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
-
-[[package]]
 name = "as-slice"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,16 +816,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
-name = "sequential-storage"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f108ff563239c0bbfcd6e72a82404d0d4682e18bbaf5a90fea1e2893318f7f9"
-dependencies = [
- "arrayvec",
- "embedded-storage",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,7 +955,6 @@ dependencies = [
  "rand_xorshift",
  "rtt-logger",
  "rtt-target",
- "sequential-storage",
  "serde",
  "serde-json-core",
  "shared-bus 0.3.1",
@@ -1083,7 +1066,7 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "usb-device"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
  "heapless",
  "num_enum 0.6.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
 name = "cortex-m"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +644,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "postcard"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
+dependencies = [
+ "cobs",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,6 +942,7 @@ dependencies = [
  "mutex-trait",
  "num_enum 0.7.1",
  "paste",
+ "postcard",
  "rand_core",
  "rand_xorshift",
  "rtt-logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "as-slice"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +432,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "menu"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03d7f798bfe97329ad6df937951142eec93886b37d87010502dd25e8cc75fd5"
+
+[[package]]
 name = "miniconf"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +608,15 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive 0.6.1",
+]
+
+[[package]]
+name = "num_enum"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683751d591e6d81200c39fb0d1032608b77724f34114db54f571ff1317b337c0"
@@ -616,6 +637,17 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "num_enum_derive"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
@@ -630,6 +662,12 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bccab0e7fd7cc19f820a1c8c91720af652d0c88dc9664dd72aef2614f04af3b"
 
 [[package]]
 name = "proc-macro-error"
@@ -784,6 +822,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
+name = "sequential-storage"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f108ff563239c0bbfcd6e72a82404d0d4682e18bbaf5a90fea1e2893318f7f9"
+dependencies = [
+ "arrayvec",
+ "embedded-storage",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,6 +952,7 @@ dependencies = [
  "cortex-m-rt",
  "cortex-m-rtic",
  "embedded-hal",
+ "embedded-storage",
  "enum-iterator",
  "fugit",
  "heapless",
@@ -911,6 +960,7 @@ dependencies = [
  "lm75",
  "log",
  "mcp230xx",
+ "menu",
  "miniconf",
  "minimq",
  "mono-clock",
@@ -921,6 +971,7 @@ dependencies = [
  "rand_xorshift",
  "rtt-logger",
  "rtt-target",
+ "sequential-storage",
  "serde",
  "serde-json-core",
  "shared-bus 0.3.1",
@@ -953,8 +1004,6 @@ dependencies = [
 [[package]]
 name = "stm32h7xx-hal"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42323c63e7ee7b6979d9370ef7f381860bbd16653bd24a30cf26e78877dbf3fb"
 dependencies = [
  "bare-metal 1.0.0",
  "cast",
@@ -996,8 +1045,6 @@ dependencies = [
 [[package]]
 name = "synopsys-usb-otg"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678f3707a7b1fd4863023292c42f73c6bab0e9b0096f41ae612d1af0ff221b45"
 dependencies = [
  "cortex-m 0.7.7",
  "embedded-hal",
@@ -1037,17 +1084,18 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 [[package]]
 name = "usb-device"
 version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
+dependencies = [
+ "heapless",
+ "num_enum 0.6.1",
+ "portable-atomic",
+]
 
 [[package]]
 name = "usbd-serial"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db75519b86287f12dcf0d171c7cf4ecc839149fe9f3b720ac4cfce52959e1dfe"
 dependencies = [
  "embedded-hal",
- "nb 0.1.3",
+ "nb 1.1.0",
  "usb-device",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,15 +602,6 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
-dependencies = [
- "num_enum_derive 0.6.1",
-]
-
-[[package]]
-name = "num_enum"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683751d591e6d81200c39fb0d1032608b77724f34114db54f571ff1317b337c0"
@@ -631,17 +622,6 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.38",
-]
-
-[[package]]
-name = "num_enum_derive"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
@@ -656,12 +636,6 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
-name = "portable-atomic"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bccab0e7fd7cc19f820a1c8c91720af652d0c88dc9664dd72aef2614f04af3b"
 
 [[package]]
 name = "proc-macro-error"
@@ -986,7 +960,9 @@ dependencies = [
 
 [[package]]
 name = "stm32h7xx-hal"
-version = "0.15.0"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08bcfbdbe4458133f2fd55994a5c4f1b4bf28084f0218e93cdbc19d7c70219f"
 dependencies = [
  "bare-metal 1.0.0",
  "cast",
@@ -1028,6 +1004,8 @@ dependencies = [
 [[package]]
 name = "synopsys-usb-otg"
 version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678f3707a7b1fd4863023292c42f73c6bab0e9b0096f41ae612d1af0ff221b45"
 dependencies = [
  "cortex-m 0.7.7",
  "embedded-hal",
@@ -1066,19 +1044,18 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "usb-device"
-version = "0.3.0"
-dependencies = [
- "heapless",
- "num_enum 0.6.1",
- "portable-atomic",
-]
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
 
 [[package]]
 name = "usbd-serial"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db75519b86287f12dcf0d171c7cf4ecc839149fe9f3b720ac4cfce52959e1dfe"
 dependencies = [
  "embedded-hal",
- "nb 1.1.0",
+ "nb 0.1.3",
  "usb-device",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,16 +63,15 @@ rand_xorshift = "0.3.0"
 rand_core = "0.6.4"
 minimq = "0.8.0"
 # patch with https://github.com/rust-embedded-community/usb-device/pull/129
-usbd-serial = {path = "../../rust-embedded-community/usbd-serial"}
+usb-device = "0.2.9"
+usbd-serial = "0.1.1"
 # Keep this synced with the miniconf version in py/setup.py
 miniconf = "0.9.0"
 smoltcp-nal = { version = "0.4.1", features = ["shared-stack"]}
 bbqueue = "0.5"
-usb-device = { path = "../../rust-embedded-community/usb-device" }
 
 [dependencies.stm32h7xx-hal]
-path = "../stm32h7xx-hal"
-#version = "0.15.0"
+version = "0.15.0"
 features = ["stm32h743v", "rt", "ethernet", "xspi", "usb_hs"]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ usbd-serial = "0.1.1"
 miniconf = "0.9.0"
 smoltcp-nal = { version = "0.4.1", features = ["shared-stack"]}
 bbqueue = "0.5"
+postcard = "1"
 
 [dependencies.stm32h7xx-hal]
 version = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ default-target = "thumbv7em-none-eabihf"
 members = ["ad9959"]
 
 [dependencies]
+embedded-storage = "0.3"
+sequential-storage = "0.4"
+menu = "0.3"
 cortex-m = { version = "0.7.7", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = { version = "0.7", features = ["device"] }
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"] }
@@ -61,15 +64,16 @@ rand_xorshift = "0.3.0"
 rand_core = "0.6.4"
 minimq = "0.8.0"
 # patch with https://github.com/rust-embedded-community/usb-device/pull/129
-usb-device = "0.2.9"
-usbd-serial = "0.1.1"
+usbd-serial = {path = "../../rust-embedded-community/usbd-serial"}
 # Keep this synced with the miniconf version in py/setup.py
 miniconf = "0.9.0"
 smoltcp-nal = { version = "0.4.1", features = ["shared-stack"]}
 bbqueue = "0.5"
+usb-device = { path = "../../rust-embedded-community/usb-device" }
 
 [dependencies.stm32h7xx-hal]
-version = "0.15.0"
+path = "../stm32h7xx-hal"
+#version = "0.15.0"
 features = ["stm32h743v", "rt", "ethernet", "xspi", "usb_hs"]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ members = ["ad9959"]
 
 [dependencies]
 embedded-storage = "0.3"
-sequential-storage = "0.4"
 menu = "0.3"
 cortex-m = { version = "0.7.7", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = { version = "0.7", features = ["device"] }

--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -180,7 +180,7 @@ python -m serial <port>
 
 Once you have opened the port, you can use the provided menu to update the MQTT broker address. The
 address can be an IP address or a domain name. Once the broker has been updated, power cycle
-stabilizer to have the new broker address take affect.
+stabilizer to have the new broker address take effect.
 
 ## Verify MQTT connection
 

--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -40,10 +40,8 @@ Stabilizer requires an MQTT broker that supports MQTTv5.
 The MQTT broker is used to distribute and exchange elemetry data and to view/change application settings.
 The broker must be reachable by both the host-side applications used to
 interact with the application on Stabilizer and by the application running on Stabilizer.
-Determine the IPv4 address of the broker as seen from the network Stabilizer is
-connected to. The broker IP address must be stable. It will be used later
-during firmware build.
-The broker must be reachable on port 1883 on that IP address.
+The broker must be reachable on port 1883 on that IP address - it may either be an IP address or a
+fully qualified domain name.
 Firewalls between Stabilizer and the broker may need to be configured to
 allow connections from Stabilizer to that port and IP address.
 
@@ -83,23 +81,21 @@ docker run -p 1883:1883 --name mosquitto -v ${pwd}/mosquitto.conf:/mosquitto/con
     git clone https://github.com/quartiq/stabilizer
     cd stabilizer
     ```
-5. Build firmware specifying the MQTT broker IP. Replace `10.34.16.1` by the
-    stable and reachable broker IPv4 address determined above.
+5. Build firmware
     ```bash
     # Bash
-    BROKER="10.34.16.1" cargo build --release
+    cargo build --release
 
     # Powershell
-    # Note: This sets the broker for all future builds as well.
-    $env:BROKER='10.34.16.1'; cargo build --release
+    cargo build --release
     ```
 6. Extract the application binary (substitute `dual-iir` below with the desired application name)
     ```bash
     # Bash
-    BROKER="10.34.16.1" cargo objcopy --release --bin dual-iir -- -O binary dual-iir.bin
+    cargo objcopy --release --bin dual-iir -- -O binary dual-iir.bin
 
     # Powershell
-    $env:BROKER='10.34.16.1'; cargo objcopy --release --bin dual-iir -- -O binary dual-iir.bin
+    cargo objcopy --release --bin dual-iir -- -O binary dual-iir.bin
     ```
 
 ## Flashing
@@ -163,15 +159,28 @@ described [above](#st-link-virtual-mass-storage).
 2. Build and run firmware on the device
     ```bash
     # Bash
-    BROKER="10.34.16.1" cargo run --release --bin dual-iir
+    cargo run --release --bin dual-iir
 
     # Powershell
-    $Env:BROKER='10.34.16.1'; cargo run --release --bin dual-iir
+    cargo run --release --bin dual-iir
     ```
 
 When using debug (non `--release`) mode, decrease the sampling frequency significantly.
 The added error checking code and missing optimizations may lead to the application
 missing timer deadlines and panicing.
+
+## Set the MQTT broker
+
+The MQTT broker can be configured via the USB port on Stabilizer's front. Connect a USB cable and
+open up the serial port in a serial terminal of your choice. `pyserial` provides a simple,
+easy-to-use terminal emulator:
+```sh
+python -m serial <port>
+```
+
+Once you have opened the port, you can use the provided menu to update the MQTT broker address. The
+address can be an IP address or a domain name. Once the broker has been updated, power cycle
+stabilizer to have the new broker address take affect.
 
 ## Verify MQTT connection
 
@@ -190,7 +199,8 @@ Broker.
 
 ![MQTT Explorer Configuration](assets/mqtt-explorer.png)
 
-> **Note:** In MQTT explorer, use the same broker address that you used when building the firmware.
+> **Note:** In MQTT explorer, use the same broker address that you set in the Stabilizer serial
+> terminal.
 
 In addition to the `alive` status, telemetry messages are published at regular intervals
 when Stabilizer has connected to the broker. Once you observe incoming telemetry,

--- a/memory.x
+++ b/memory.x
@@ -44,3 +44,9 @@ BUG(cortex-m-rt): .itcm is not 8-byte aligned");
 
 ASSERT(__siitcm % 4 == 0, "
 BUG(cortex-m-rt): the LMA of .itcm is not 4-byte aligned");
+
+/* Place the stack in AXISRAM.
+ * Note: This is done because the sequential-storage crate needs to buffer flash sectors on
+ * the stack, each of which are 128KB. This can cause for excessive stack sizes.
+ */
+_stack_start = ORIGIN(AXISRAM) + LENGTH(AXISRAM);

--- a/memory.x
+++ b/memory.x
@@ -44,9 +44,3 @@ BUG(cortex-m-rt): .itcm is not 8-byte aligned");
 
 ASSERT(__siitcm % 4 == 0, "
 BUG(cortex-m-rt): the LMA of .itcm is not 4-byte aligned");
-
-/* Place the stack in AXISRAM.
- * Note: This is done because the sequential-storage crate needs to buffer flash sectors on
- * the stack, each of which are 128KB. This can cause for excessive stack sizes.
- */
-_stack_start = ORIGIN(AXISRAM) + LENGTH(AXISRAM);

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -67,7 +67,7 @@ const BATCH_SIZE: usize = 8;
 
 // The logarithm of the number of 100MHz timer ticks between each sample. With a value of 2^7 =
 // 128, there is 1.28uS per sample, corresponding to a sampling frequency of 781.25 KHz.
-const SAMPLE_TICKS_LOG2: u8 = 7;
+const SAMPLE_TICKS_LOG2: u8 = 8;
 const SAMPLE_TICKS: u32 = 1 << SAMPLE_TICKS_LOG2;
 const SAMPLE_PERIOD: f32 =
     SAMPLE_TICKS as f32 * hardware::design_parameters::TIMER_PERIOD;

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -67,7 +67,7 @@ const BATCH_SIZE: usize = 8;
 
 // The logarithm of the number of 100MHz timer ticks between each sample. With a value of 2^7 =
 // 128, there is 1.28uS per sample, corresponding to a sampling frequency of 781.25 KHz.
-const SAMPLE_TICKS_LOG2: u8 = 8;
+const SAMPLE_TICKS_LOG2: u8 = 7;
 const SAMPLE_TICKS: u32 = 1 << SAMPLE_TICKS_LOG2;
 const SAMPLE_PERIOD: f32 =
     SAMPLE_TICKS as f32 * hardware::design_parameters::TIMER_PERIOD;

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -216,14 +216,14 @@ mod app {
             SAMPLE_TICKS,
         );
 
+        let flash = stabilizer.usb_serial.flash();
         let mut network = NetworkUsers::new(
             stabilizer.net.stack,
             stabilizer.net.phy,
             clock,
             env!("CARGO_BIN_NAME"),
-            stabilizer.net.mac_address,
-            stabilizer.usb_serial.flash().fetch_item("broker"),
-            stabilizer.usb_serial.flash().fetch_item("id"),
+            &flash.settings.broker,
+            &flash.settings.id,
         );
 
         let generator = network.configure_streaming(StreamFormat::AdcDacData);

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -208,7 +208,7 @@ mod app {
         let clock = SystemTimer::new(|| monotonics::now().ticks() as u32);
 
         // Configure the microcontroller
-        let (stabilizer, _pounder) = hardware::setup::setup(
+        let (mut stabilizer, _pounder) = hardware::setup::setup(
             c.core,
             c.device,
             clock,
@@ -222,7 +222,8 @@ mod app {
             clock,
             env!("CARGO_BIN_NAME"),
             stabilizer.net.mac_address,
-            option_env!("BROKER").unwrap_or("mqtt"),
+            stabilizer.usb_serial.flash().fetch_item("broker"),
+            stabilizer.usb_serial.flash().fetch_item("id"),
         );
 
         let generator = network.configure_streaming(StreamFormat::AdcDacData);

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -262,7 +262,8 @@ mod app {
             clock,
             env!("CARGO_BIN_NAME"),
             stabilizer.net.mac_address,
-            option_env!("BROKER").unwrap_or("mqtt"),
+            stabilizer.usb_serial.flash().fetch_item("broker"),
+            stabilizer.usb_serial.flash().fetch_item("id"),
         );
 
         let generator = network.configure_streaming(StreamFormat::AdcDacData);

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -37,7 +37,7 @@ use core::{
 use fugit::ExtU64;
 use mutex_trait::prelude::*;
 
-use idsp::{Accu, Chain, Complex, ComplexExt, Filter, Lockin, Lowpass, RPLL};
+use idsp::{Accu, Complex, ComplexExt, Filter, Lockin, Lowpass, Repeat, RPLL};
 
 use stabilizer::{
     hardware::{
@@ -237,7 +237,7 @@ mod app {
         adcs: (Adc0Input, Adc1Input),
         dacs: (Dac0Output, Dac1Output),
         pll: RPLL,
-        lockin: Lockin<Chain<2, Lowpass<2>>>,
+        lockin: Lockin<Repeat<2, Lowpass<2>>>,
         signal_generator: signal_generator::SignalGenerator,
         generator: FrameGenerator,
         cpu_temp_sensor: stabilizer::hardware::cpu_temp_sensor::CpuTempSensor,

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -37,7 +37,7 @@ use core::{
 use fugit::ExtU64;
 use mutex_trait::prelude::*;
 
-use idsp::{Accu, Complex, ComplexExt, Filter, Lockin, Lowpass, Repeat, RPLL};
+use idsp::{Accu, Chain, Complex, ComplexExt, Filter, Lockin, Lowpass, RPLL};
 
 use stabilizer::{
     hardware::{
@@ -237,7 +237,7 @@ mod app {
         adcs: (Adc0Input, Adc1Input),
         dacs: (Dac0Output, Dac1Output),
         pll: RPLL,
-        lockin: Lockin<Repeat<2, Lowpass<2>>>,
+        lockin: Lockin<Chain<2, Lowpass<2>>>,
         signal_generator: signal_generator::SignalGenerator,
         generator: FrameGenerator,
         cpu_temp_sensor: stabilizer::hardware::cpu_temp_sensor::CpuTempSensor,

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -256,14 +256,14 @@ mod app {
             SAMPLE_TICKS,
         );
 
+        let flash = stabilizer.usb_serial.flash();
         let mut network = NetworkUsers::new(
             stabilizer.net.stack,
             stabilizer.net.phy,
             clock,
             env!("CARGO_BIN_NAME"),
-            stabilizer.net.mac_address,
-            stabilizer.usb_serial.flash().fetch_item("broker"),
-            stabilizer.usb_serial.flash().fetch_item("id"),
+            &flash.settings.broker,
+            &flash.settings.id,
         );
 
         let generator = network.configure_streaming(StreamFormat::AdcDacData);

--- a/src/hardware/flash.rs
+++ b/src/hardware/flash.rs
@@ -1,0 +1,82 @@
+use stm32h7xx_hal::flash::{UnlockedFlashBank, LockedFlashBank};
+use embedded_storage::nor_flash::NorFlash;
+#[derive(Debug)]
+pub enum StorageError {
+    JsonDe(serde_json_core::de::Error),
+    JsonSer(serde_json_core::ser::Error),
+}
+
+impl From<serde_json_core::de::Error> for StorageError {
+    fn from(e: serde_json_core::de::Error) -> Self {
+        Self::JsonDe(e)
+    }
+}
+
+impl From<serde_json_core::ser::Error> for StorageError {
+    fn from(e: serde_json_core::ser::Error) -> Self {
+        Self::JsonSer(e)
+    }
+}
+
+impl sequential_storage::map::StorageItemError for StorageError {
+    fn is_buffer_too_small(&self) -> bool {
+        match self {
+            Self::JsonSer(serde_json_core::ser::Error::BufferFull) => true,
+            Self::JsonDe(serde_json_core::de::Error::EofWhileParsingString) => true,
+            Self::JsonDe(serde_json_core::de::Error::EofWhileParsingList) => true,
+            Self::JsonDe(serde_json_core::de::Error::EofWhileParsingObject) => true,
+            Self::JsonDe(serde_json_core::de::Error::EofWhileParsingNumber) => true,
+            Self::JsonDe(serde_json_core::de::Error::EofWhileParsingValue) => true,
+            _ => false,
+        }
+    }
+}
+
+macro_rules! storage_item {
+    ($len:literal, $key:literal, $name:ident) => {
+        pub struct $name(pub heapless::String<$len>);
+
+        impl sequential_storage::map::StorageItem for $name {
+            type Key = &'static str;
+            type Error = StorageError;
+
+            fn serialize_into(&self, buffer: &mut [u8]) -> Result<usize, Self::Error> {
+                Ok(serde_json_core::to_slice(&self.0, buffer)?)
+            }
+
+            fn deserialize_from(buffer: &[u8]) -> Result<(Self, usize), Self::Error> {
+                Ok(serde_json_core::from_slice(buffer).map(|(item, size)| (Self(item), size))?)
+            }
+
+            fn key(&self) -> Self::Key {
+                $key
+            }
+        }
+    }
+}
+
+
+storage_item!(23, "id", MqttIdentifier);
+storage_item!(255, "broker", BrokerAddress);
+
+pub struct FlashSettings {
+    flash: LockedFlashBank,
+}
+
+impl FlashSettings {
+    pub fn new(flash: LockedFlashBank) -> Self {
+        Self { flash }
+    }
+
+    pub fn store_item(&mut self, item: impl sequential_storage::map::StorageItem) {
+        let mut bank = self.flash.unlocked();
+        let range = (bank.address() as u32)..((bank.address() + bank.len()) as u32);
+        sequential_storage::map::store_item::<_, _, { <UnlockedFlashBank as NorFlash>::ERASE_SIZE } >(&mut bank, range, item).unwrap();
+    }
+
+    pub fn fetch_item<I: sequential_storage::map::StorageItem<Key=&'static str>>(&mut self, key: &'static str) -> Option<I> {
+        let mut bank = self.flash.unlocked();
+        let range = (bank.address() as u32)..((bank.address() + bank.len()) as u32);
+        sequential_storage::map::fetch_item(&mut bank, range, key).unwrap()
+    }
+}

--- a/src/hardware/flash.rs
+++ b/src/hardware/flash.rs
@@ -6,6 +6,9 @@ use stm32h7xx_hal::flash::{LockedFlashBank, UnlockedFlashBank};
 pub struct Settings {
     pub broker: heapless::String<255>,
     pub id: heapless::String<23>,
+    #[serde(skip)]
+    #[tree(skip)]
+    pub mac: smoltcp_nal::smoltcp::wire::EthernetAddress,
 }
 
 impl Settings {
@@ -16,7 +19,12 @@ impl Settings {
         Self {
             broker: "mqtt".into(),
             id,
+            mac,
         }
+    }
+
+    pub fn reset(&mut self) {
+        *self = Self::new(self.mac)
     }
 }
 

--- a/src/hardware/flash.rs
+++ b/src/hardware/flash.rs
@@ -2,7 +2,7 @@ use core::fmt::Write;
 use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
 use stm32h7xx_hal::flash::{LockedFlashBank, UnlockedFlashBank};
 
-#[derive(serde::Serialize, serde::Deserialize, miniconf::Tree)]
+#[derive(Clone, serde::Serialize, serde::Deserialize, miniconf::Tree)]
 pub struct Settings {
     pub broker: heapless::String<255>,
     pub id: heapless::String<23>,

--- a/src/hardware/flash.rs
+++ b/src/hardware/flash.rs
@@ -34,26 +34,30 @@ impl FlashSettings {
         // We iteratively read the settings from flash to allow for easy expansion of the settings
         // without losing data in the future when new fields are added.
         flash.read(offset as u32, &mut buffer[..]).unwrap();
+        let len = buffer.iter().skip(1).position(|x| x == &b'"').unwrap_or(0) + 2;
         settings.broker = {
-            match serde_json_core::from_slice(&buffer[..]) {
+            match serde_json_core::from_slice(&buffer[..len]) {
                 Ok((item, size)) => {
                     offset += size;
                     item
                 }
-                Err(_) => {
+                Err(e) => {
+                    log::warn!("Failed to decode broker from flash settings memory - using default: {e:?}");
                     settings.broker
                 }
             }
         };
 
         flash.read(offset as u32, &mut buffer[..]).unwrap();
+        let len = buffer.iter().skip(1).position(|x| x == &b'"').unwrap_or(0) + 2;
         settings.id = {
-            match serde_json_core::from_slice(&buffer[..]) {
+            match serde_json_core::from_slice(&buffer[..len]) {
                 Ok((item, size)) => {
                     offset += size;
                     item
                 }
-                Err(_) => {
+                Err(e) => {
+                    log::warn!("Failed to MQTT ID from flash settings memory - using default: {e:?}");
                     settings.id
                 }
             }

--- a/src/hardware/flash.rs
+++ b/src/hardware/flash.rs
@@ -1,6 +1,6 @@
-use embedded_storage::nor_flash::{ReadNorFlash, NorFlash};
-use stm32h7xx_hal::flash::{LockedFlashBank, UnlockedFlashBank};
 use core::fmt::Write;
+use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
+use stm32h7xx_hal::flash::{LockedFlashBank, UnlockedFlashBank};
 
 #[derive(miniconf::Tree)]
 pub struct Settings {
@@ -26,7 +26,10 @@ pub struct FlashSettings {
 }
 
 impl FlashSettings {
-    pub fn new(mut flash: LockedFlashBank, mac: smoltcp_nal::smoltcp::wire::EthernetAddress) -> Self {
+    pub fn new(
+        mut flash: LockedFlashBank,
+        mac: smoltcp_nal::smoltcp::wire::EthernetAddress,
+    ) -> Self {
         let mut settings = Settings::new(mac);
         let mut buffer = [0u8; 256];
         let mut offset: usize = 0;
@@ -34,7 +37,8 @@ impl FlashSettings {
         // We iteratively read the settings from flash to allow for easy expansion of the settings
         // without losing data in the future when new fields are added.
         flash.read(offset as u32, &mut buffer[..]).unwrap();
-        let len = buffer.iter().skip(1).position(|x| x == &b'"').unwrap_or(0) + 2;
+        let len =
+            buffer.iter().skip(1).position(|x| x == &b'"').unwrap_or(0) + 2;
         settings.broker = {
             match serde_json_core::from_slice(&buffer[..len]) {
                 Ok((item, size)) => {
@@ -49,11 +53,11 @@ impl FlashSettings {
         };
 
         flash.read(offset as u32, &mut buffer[..]).unwrap();
-        let len = buffer.iter().skip(1).position(|x| x == &b'"').unwrap_or(0) + 2;
+        let len =
+            buffer.iter().skip(1).position(|x| x == &b'"').unwrap_or(0) + 2;
         settings.id = {
             match serde_json_core::from_slice(&buffer[..len]) {
                 Ok((item, size)) => {
-                    offset += size;
                     item
                 }
                 Err(e) => {
@@ -70,8 +74,14 @@ impl FlashSettings {
         let mut bank = self.flash.unlocked();
         let mut data = [0; 512];
         let mut offset: usize = 0;
-        offset += serde_json_core::to_slice(&self.settings.broker, &mut data[offset..]).unwrap();
-        offset += serde_json_core::to_slice(&self.settings.id, &mut data[offset..]).unwrap();
+        offset += serde_json_core::to_slice(
+            &self.settings.broker,
+            &mut data[offset..],
+        )
+        .unwrap();
+        offset +=
+            serde_json_core::to_slice(&self.settings.id, &mut data[offset..])
+                .unwrap();
 
         bank.erase(0, UnlockedFlashBank::ERASE_SIZE as u32).unwrap();
         bank.write(0, &data[..offset]).unwrap();

--- a/src/hardware/flash.rs
+++ b/src/hardware/flash.rs
@@ -2,7 +2,7 @@ use core::fmt::Write;
 use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
 use stm32h7xx_hal::flash::{LockedFlashBank, UnlockedFlashBank};
 
-#[derive(miniconf::Tree)]
+#[derive(serde::Serialize, serde::Deserialize, miniconf::Tree)]
 pub struct Settings {
     pub broker: heapless::String<255>,
     pub id: heapless::String<23>,
@@ -30,34 +30,16 @@ impl FlashSettings {
         mut flash: LockedFlashBank,
         mac: smoltcp_nal::smoltcp::wire::EthernetAddress,
     ) -> Self {
-        let mut settings = Settings::new(mac);
         let mut buffer = [0u8; 512];
         flash.read(0, &mut buffer[..]).unwrap();
 
-        let mut data = &buffer[..];
-
-        // We iteratively read the settings from flash to allow for easy expansion of the settings
-        // without losing data in the future when new fields are added.
-        settings.broker = {
-            match postcard::take_from_bytes(data) {
-                Ok((item, remainder)) => {
-                    data = remainder;
-                    item
-                }
-                Err(e) => {
-                    log::warn!("Failed to decode broker from flash settings memory - using default: {e:?}");
-                    settings.broker
-                }
-            }
-        };
-
-        settings.id = {
-            match postcard::from_bytes(data) {
-                Ok(item) => item,
-                Err(e) => {
-                    log::warn!("Failed to MQTT ID from flash settings memory - using default: {e:?}");
-                    settings.id
-                }
+        let settings = match postcard::from_bytes(&buffer) {
+            Ok(settings) => settings,
+            Err(_) => {
+                log::warn!(
+                    "Failed to load settings from flash. Using defaults"
+                );
+                Settings::new(mac)
             }
         };
 
@@ -68,16 +50,8 @@ impl FlashSettings {
         let mut bank = self.flash.unlocked();
 
         let mut data = [0; 512];
-        let mut offset: usize = 0;
-        offset +=
-            postcard::to_slice(&self.settings.broker, &mut data[offset..])
-                .unwrap()
-                .len();
-        offset += postcard::to_slice(&self.settings.id, &mut data[offset..])
-            .unwrap()
-            .len();
-
+        let serialized = postcard::to_slice(&self.settings, &mut data).unwrap();
         bank.erase(0, UnlockedFlashBank::ERASE_SIZE as u32).unwrap();
-        bank.write(0, &data[..offset]).unwrap();
+        bank.write(0, serialized).unwrap();
     }
 }

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -9,6 +9,7 @@ pub mod cpu_temp_sensor;
 pub mod dac;
 pub mod delay;
 pub mod design_parameters;
+pub mod flash;
 pub mod input_stamper;
 pub mod pounder;
 pub mod serial_terminal;
@@ -16,7 +17,6 @@ pub mod setup;
 pub mod shared_adc;
 pub mod signal_generator;
 pub mod timers;
-pub mod flash;
 
 mod eeprom;
 

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -16,6 +16,7 @@ pub mod setup;
 pub mod shared_adc;
 pub mod signal_generator;
 pub mod timers;
+pub mod flash;
 
 mod eeprom;
 

--- a/src/hardware/serial_terminal.rs
+++ b/src/hardware/serial_terminal.rs
@@ -16,7 +16,7 @@ const ROOT_MENU: menu::Menu<Context> = menu::Menu {
             command: "reboot",
             help: Some("Reboot the device to force new settings to take effect."),
             item_type: menu::ItemType::Callback {
-                function: handle_device_reboot,
+                function: handle_reboot,
                 parameters: &[]
             },
         },
@@ -24,7 +24,7 @@ const ROOT_MENU: menu::Menu<Context> = menu::Menu {
             command: "factory-reset",
             help: Some("Reset the device settings to default values."),
             item_type: menu::ItemType::Callback {
-                function: handle_settings_reset,
+                function: handle_reset,
                 parameters: &[]
             },
         },
@@ -37,10 +37,10 @@ const ROOT_MENU: menu::Menu<Context> = menu::Menu {
             },
         },
         &menu::Item {
-            command: "read",
+            command: "get",
             help: Some("Read a setting_from the device."),
             item_type: menu::ItemType::Callback {
-                function: handle_setting_read,
+                function: handle_get,
                 parameters: &[menu::Parameter::Mandatory {
                     parameter_name: "item",
                     help: Some("The name of the setting to read."),
@@ -48,10 +48,10 @@ const ROOT_MENU: menu::Menu<Context> = menu::Menu {
             },
         },
         &menu::Item {
-            command: "write",
+            command: "set",
             help: Some("Update a a setting in the device."),
             item_type: menu::ItemType::Callback {
-                function: handle_setting_write,
+                function: handle_set,
                 parameters: &[
                     menu::Parameter::Mandatory {
                         parameter_name: "item",
@@ -134,7 +134,7 @@ fn handle_list(
     }
 }
 
-fn handle_device_reboot(
+fn handle_reboot(
     _menu: &menu::Menu<Context>,
     _item: &menu::Item<Context>,
     _args: &[&str],
@@ -143,7 +143,7 @@ fn handle_device_reboot(
     cortex_m::peripheral::SCB::sys_reset();
 }
 
-fn handle_settings_reset(
+fn handle_reset(
     _menu: &menu::Menu<Context>,
     _item: &menu::Item<Context>,
     _args: &[&str],
@@ -153,7 +153,7 @@ fn handle_settings_reset(
     context.flash.save();
 }
 
-fn handle_setting_read(
+fn handle_get(
     _menu: &menu::Menu<Context>,
     item: &menu::Item<Context>,
     args: &[&str],
@@ -173,7 +173,7 @@ fn handle_setting_read(
     writeln!(context, "{key}: {stringified}").unwrap();
 }
 
-fn handle_setting_write(
+fn handle_set(
     _menu: &menu::Menu<Context>,
     item: &menu::Item<Context>,
     args: &[&str],

--- a/src/hardware/serial_terminal.rs
+++ b/src/hardware/serial_terminal.rs
@@ -12,6 +12,14 @@ const ROOT_MENU: menu::Menu<Context> = menu::Menu {
     label: "root",
     items: &[
         &menu::Item {
+            command: "reset",
+            help: Some("Reset Stabilizer to force new settings to take effect."),
+            item_type: menu::ItemType::Callback {
+                function: handle_reset,
+                parameters: &[]
+            },
+        },
+        &menu::Item {
             command: "read",
             help: Some("Read a property from the device:
 
@@ -84,6 +92,15 @@ impl core::fmt::Write for Context {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         self.output.write_str(s)
     }
+}
+
+fn handle_reset(
+    _menu: &menu::Menu<Context>,
+    _item: &menu::Item<Context>,
+    _args: &[&str],
+    _context: &mut Context,
+) {
+    cortex_m::peripheral::SCB::sys_reset();
 }
 
 fn handle_property_read(

--- a/src/hardware/serial_terminal.rs
+++ b/src/hardware/serial_terminal.rs
@@ -1,5 +1,55 @@
 use super::UsbBus;
 use core::fmt::Write;
+use crate::hardware::flash::{MqttIdentifier, BrokerAddress, FlashSettings};
+
+struct Context {
+    output: OutputBuffer,
+    flash: FlashSettings,
+}
+
+const ROOT_MENU: menu::Menu<Context> = menu::Menu {
+    label: "root",
+    items: &[
+        &menu::Item {
+            command: "read",
+            help: Some("Read a property from the device:
+
+Available Properties:
+* id: The MQTT ID of the device
+* broker: The MQTT broker address"),
+            item_type: menu::ItemType::Callback {
+                function: handle_property_read,
+                parameters: &[menu::Parameter::Optional {
+                    parameter_name: "property",
+                    help: Some("The name of the property to read. If not specified, all properties are read"),
+                }]
+            },
+        },
+        &menu::Item {
+            command: "write",
+            help: Some("Write a property to the device:
+
+Available Properties:
+* id: The MQTT ID of the device
+* broker: The MQTT broker address"),
+            item_type: menu::ItemType::Callback {
+                function: handle_property_write,
+                parameters: &[
+                    menu::Parameter::Mandatory {
+                        parameter_name: "property",
+                        help: Some("The name of the property to write: [id, broker]"),
+                    },
+                    menu::Parameter::Mandatory {
+                        parameter_name: "value",
+                        help: Some("Specifies the value to be written to the property."),
+                    },
+                ]
+            },
+        },
+    ],
+    entry: None,
+    exit: None,
+};
 
 static OUTPUT_BUFFER: bbqueue::BBBuffer<512> = bbqueue::BBBuffer::new();
 
@@ -25,22 +75,101 @@ impl Write for OutputBuffer {
     }
 }
 
+impl core::fmt::Write for Context {
+    /// Write data to the serial terminal.
+    ///
+    /// # Note
+    /// The terminal uses an internal buffer. Overflows of the output buffer are silently ignored.
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.output.write_str(s)
+    }
+}
+
+fn handle_property_read(
+    _menu: &menu::Menu<Context>,
+    item: &menu::Item<Context>,
+    args: &[&str],
+    context: &mut Context,
+) {
+    let props: heapless::Vec<&'_ str, 2> = if let Some(prop) = menu::argument_finder(item, args, "property").unwrap() {
+        heapless::Vec::from_slice(&[prop]).unwrap()
+    } else {
+        heapless::Vec::from_slice(&["id", "broker"]).unwrap()
+    };
+
+    for prop in props {
+        write!(&mut context.output, "{prop}: ").unwrap();
+        match prop {
+            "id" => {
+                let value = context.flash.fetch_item::<MqttIdentifier>("mqtt-id").unwrap().0;
+                writeln!(&mut context.output, "{value}").unwrap();
+            }
+
+            "broker" => {
+                let value = context.flash.fetch_item::<BrokerAddress>("broker").unwrap().0;
+                writeln!(&mut context.output, "{value}").unwrap();
+            }
+
+            _ => {
+                writeln!(&mut context.output, "Unknown property").unwrap();
+                return;
+            }
+        }
+    }
+}
+
+fn handle_property_write(
+    _menu: &menu::Menu<Context>,
+    item: &menu::Item<Context>,
+    args: &[&str],
+    context: &mut Context,
+) {
+    let property = menu::argument_finder(item, args, "property")
+        .unwrap()
+        .unwrap();
+    let value = menu::argument_finder(item, args, "value").unwrap().unwrap();
+
+    // Now, write the new value into memory.
+    // TODO: Validate it first?
+    match property {
+        "id" => context.flash.store_item(MqttIdentifier(heapless::String::from(value))),
+        "broker" => context.flash.store_item(BrokerAddress(heapless::String::from(value))),
+        other => {
+            writeln!(&mut context.output, "Unknown property: {other}").unwrap();
+            return;
+        }
+    }
+
+    writeln!(
+        &mut context.output,
+        "Settings in memory may differ from currently operating settings. \
+Reset device to apply settings."
+    )
+    .unwrap();
+}
+
 pub struct SerialTerminal {
     usb_device: usb_device::device::UsbDevice<'static, UsbBus>,
     usb_serial: usbd_serial::SerialPort<'static, UsbBus>,
+    menu: menu::Runner<'static, Context>,
     output: bbqueue::Consumer<'static, 512>,
-    buffer: OutputBuffer,
 }
 
 impl SerialTerminal {
     pub fn new(
         usb_device: usb_device::device::UsbDevice<'static, UsbBus>,
         usb_serial: usbd_serial::SerialPort<'static, UsbBus>,
+        flash: FlashSettings,
     ) -> Self {
         let (producer, consumer) = OUTPUT_BUFFER.try_split().unwrap();
 
+        let input_buffer = cortex_m::singleton!(: [u8; 255] = [0; 255]).unwrap();
+        let context = Context {
+            output: OutputBuffer { producer },
+            flash,
+        };
         Self {
-            buffer: OutputBuffer { producer },
+            menu: menu::Runner::new(&ROOT_MENU, input_buffer, context),
             usb_device,
             usb_serial,
             output: consumer,
@@ -79,17 +208,17 @@ impl SerialTerminal {
         match self.usb_serial.read(&mut buffer) {
             Ok(count) => {
                 for &value in &buffer[..count] {
-                    writeln!(self.buffer, "echo: {}", value as char).unwrap();
+                    self.menu.input_byte(value);
                 }
             }
 
             Err(usbd_serial::UsbError::WouldBlock) => {}
             Err(_) => {
-                // Clear the output buffer if USB is not connected.
-                while let Ok(grant) = self.output.read() {
+                self.menu.prompt(true);
+                self.output.read().map(|grant| {
                     let len = grant.buf().len();
                     grant.release(len);
-                }
+                }).ok();
             }
         }
     }

--- a/src/hardware/serial_terminal.rs
+++ b/src/hardware/serial_terminal.rs
@@ -102,9 +102,9 @@ fn handle_property_read(
 
     let mut buf = [0u8; 256];
     for path in props {
-        let len = context.flash.settings.get_json(&path, &mut buf).unwrap();
+        let len = context.flash.settings.get_json(path, &mut buf).unwrap();
         let stringified = core::str::from_utf8(&buf[..len]).unwrap();
-        write!(&mut context.output, "{path}: {stringified}").unwrap();
+        writeln!(&mut context.output, "{path}: {stringified}").unwrap();
     }
 }
 
@@ -123,6 +123,7 @@ fn handle_property_write(
     // TODO: Validate it first?
     match context.flash.settings.set_json(property, value.as_bytes()) {
         Ok(_) => {
+            context.flash.save();
             writeln!(
                 &mut context.output,
                 "Settings in memory may differ from currently operating settings. \

--- a/src/hardware/serial_terminal.rs
+++ b/src/hardware/serial_terminal.rs
@@ -119,7 +119,15 @@ fn handle_property_read(
 
     let mut buf = [0u8; 256];
     for path in props {
-        let len = context.flash.settings.get_json(path, &mut buf).unwrap();
+        let len = match context.flash.settings.get_json(path, &mut buf) {
+            Err(e) => {
+                writeln!(&mut context.output, "Failed to read {path}: {e}")
+                    .unwrap();
+                return;
+            }
+            Ok(len) => len,
+        };
+
         let stringified = core::str::from_utf8(&buf[..len]).unwrap();
         writeln!(&mut context.output, "{path}: {stringified}").unwrap();
     }
@@ -149,7 +157,8 @@ fn handle_property_write(
     .unwrap();
         }
         Err(e) => {
-            writeln!(&mut context.output, "Failed to update {property}: {e:?}").unwrap();
+            writeln!(&mut context.output, "Failed to update {property}: {e:?}")
+                .unwrap();
         }
     }
 }

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -1072,7 +1072,8 @@ pub fn setup(
 
     let (_, flash_bank2) = device.FLASH.split();
 
-    let settings = FlashSettings::new(flash_bank2.unwrap(), network_devices.mac_address.clone());
+    let settings =
+        FlashSettings::new(flash_bank2.unwrap(), network_devices.mac_address);
 
     let stabilizer = StabilizerDevices {
         systick,

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -14,12 +14,11 @@ use smoltcp_nal::smoltcp;
 
 use super::{
     adc, afe, cpu_temp_sensor::CpuTempSensor, dac, delay, design_parameters,
-    eeprom, input_stamper::InputStamper, pounder,
+    eeprom, flash::FlashSettings, input_stamper::InputStamper, pounder,
     pounder::dds_output::DdsOutput, serial_terminal::SerialTerminal,
     shared_adc::SharedAdc, timers, DigitalInput0, DigitalInput1,
     EemDigitalInput0, EemDigitalInput1, EemDigitalOutput0, EemDigitalOutput1,
     EthernetPhy, NetworkStack, SystemTimer, Systick, UsbBus, AFE0, AFE1,
-    flash::FlashSettings,
 };
 
 const NUM_TCP_SOCKETS: usize = 4;
@@ -1062,7 +1061,11 @@ pub fn setup(
             usb_bus.as_ref().unwrap(),
             usb_device::device::UsbVidPid(0x1209, 0x392F),
         )
-        .strings(&[usb_device::device::StringDescriptors::default().manufacturer("ARTIQ/Sinara").product("Stabilizer").serial_number(serial_number.as_ref().unwrap())]).unwrap()
+        .strings(&[usb_device::device::StringDescriptors::default()
+            .manufacturer("ARTIQ/Sinara")
+            .product("Stabilizer")
+            .serial_number(serial_number.as_ref().unwrap())])
+        .unwrap()
         .device_class(usbd_serial::USB_CLASS_CDC)
         .build();
 

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -1074,7 +1074,7 @@ pub fn setup(
 
     let (_, flash_bank2) = device.FLASH.split();
 
-    let settings = FlashSettings::new(flash_bank2.unwrap());
+    let settings = FlashSettings::new(flash_bank2.unwrap(), network_devices.mac_address.clone());
 
     let stabilizer = StabilizerDevices {
         systick,

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -1061,11 +1061,9 @@ pub fn setup(
             usb_bus.as_ref().unwrap(),
             usb_device::device::UsbVidPid(0x1209, 0x392F),
         )
-        .strings(&[usb_device::device::StringDescriptors::default()
-            .manufacturer("ARTIQ/Sinara")
-            .product("Stabilizer")
-            .serial_number(serial_number.as_ref().unwrap())])
-        .unwrap()
+        .manufacturer("ARTIQ/Sinara")
+        .product("Stabilizer")
+        .serial_number(serial_number.as_ref().unwrap())
         .device_class(usbd_serial::USB_CLASS_CDC)
         .build();
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -13,9 +13,7 @@ pub mod data_stream;
 pub mod network_processor;
 pub mod telemetry;
 
-use crate::hardware::{
-    EthernetPhy, NetworkManager, NetworkStack, SystemTimer,
-};
+use crate::hardware::{EthernetPhy, NetworkManager, NetworkStack, SystemTimer};
 use data_stream::{DataStream, FrameGenerator};
 use network_processor::NetworkProcessor;
 use telemetry::TelemetryClient;
@@ -224,10 +222,7 @@ where
 ///
 /// # Returns
 /// A client ID that may be used for MQTT client identification.
-fn get_client_id(
-    id: &str,
-    mode: &str,
-) -> String<64> {
+fn get_client_id(id: &str, mode: &str) -> String<64> {
     let mut identifier = String::new();
     write!(&mut identifier, "{id}-{mode}").unwrap();
     identifier

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -125,7 +125,7 @@ where
                 named_broker,
                 &mut store.settings,
             )
-            .client_id(id)
+            .client_id(&get_client_id(id, "settings"))
             .unwrap(),
         )
         .unwrap();
@@ -142,7 +142,7 @@ where
                 // The telemetry client doesn't receive any messages except MQTT control packets.
                 // As such, we don't need much of the buffer for RX.
                 .rx_buffer(minimq::config::BufferConfig::Maximum(100))
-                .client_id(id)
+                .client_id(&get_client_id(id, "tlm"))
                 .unwrap(),
         );
 
@@ -214,6 +214,23 @@ where
             _ => poll_result,
         }
     }
+}
+
+/// Get an MQTT client ID for a client.
+///
+/// # Args
+/// * `id` - The base client ID
+/// * `mode` - The operating mode of this client. (i.e. tlm, settings)
+///
+/// # Returns
+/// A client ID that may be used for MQTT client identification.
+fn get_client_id(
+    id: &str,
+    mode: &str,
+) -> String<64> {
+    let mut identifier = String::new();
+    write!(&mut identifier, "{id}-{mode}").unwrap();
+    identifier
 }
 
 /// Get the MQTT prefix of a device.


### PR DESCRIPTION
This PR fixes #351 by storing the MQTT broker address and the stabilizer ID in the unused flash bank.

TODO:
- [x] Update code to use parameters stored in flash on startup
- [x] Verify parameters are not lost during flashing