### PR TITLE
Fixing minor issues with default listing

### DIFF
--- a/src/hardware/flash.rs
+++ b/src/hardware/flash.rs
@@ -45,7 +45,7 @@ impl FlashSettings {
             Ok(mut settings) => {
                 settings.mac = mac;
                 settings
-            },
+            }
             Err(_) => {
                 log::warn!(
                     "Failed to load settings from flash. Using defaults"

--- a/src/hardware/flash.rs
+++ b/src/hardware/flash.rs
@@ -41,8 +41,11 @@ impl FlashSettings {
         let mut buffer = [0u8; 512];
         flash.read(0, &mut buffer[..]).unwrap();
 
-        let settings = match postcard::from_bytes(&buffer) {
-            Ok(settings) => settings,
+        let settings = match postcard::from_bytes::<Settings>(&buffer) {
+            Ok(mut settings) => {
+                settings.mac = mac;
+                settings
+            },
             Err(_) => {
                 log::warn!(
                     "Failed to load settings from flash. Using defaults"

--- a/src/hardware/serial_terminal.rs
+++ b/src/hardware/serial_terminal.rs
@@ -109,7 +109,7 @@ fn handle_list(
     _args: &[&str],
     context: &mut Context,
 ) {
-    writeln!(context, "Available properties:").unwrap();
+    writeln!(context, "Available items:").unwrap();
 
     let mut defaults = context.flash.settings.clone();
     defaults.reset();


### PR DESCRIPTION
When deserializing, the MAC is skipped, and we need to set it so we know the default UID. Otherwise, the defaults show the MAC as 00-00-00-00-00-00. After the change:

```
PS C:\Users\rsummers> python -m serial COM22
--- Miniterm on COM22  9600,8,N,1 ---
--- Quit: Ctrl+] | Menu: Ctrl+T | Help: Ctrl+T followed by Ctrl+H ---

Input was empty?

> list
Available items:
/broker: "mqtt" [default: "mqtt"]
/id: "04-91-62-d2-a8-6f" [default: "04-91-62-d2-a8-6f"]
```