### PR TITLE
Feature/pounder v1.2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased](https://github.com/quartiq/stabilizer/compare/v0.9.0...HEAD)
+
+### Added
+* Support added for pounder v1.2
+* Serial terminal is available on USB for settings configurations
+
+### Changed
+* Broker is no longer configured at compile time, but is maintained in device memory
+
 ## [0.9.0](https://github.com/quartiq/stabilizer/compare/v0.8.1...v0.9.0)
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,6 +954,7 @@ dependencies = [
  "spin",
  "stm32h7xx-hal",
  "systick-monotonic",
+ "tca9539",
  "usb-device",
  "usbd-serial",
 ]
@@ -1040,6 +1041,17 @@ dependencies = [
  "cortex-m 0.7.7",
  "fugit",
  "rtic-monotonic",
+]
+
+[[package]]
+name = "tca9539"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05458b00a3a73c5b64c0de8f2a5182f6d51eb1aeb54c638e585092d26fc9a971"
+dependencies = [
+ "bit_field",
+ "embedded-hal",
+ "num_enum 0.5.11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = ["ad9959"]
 
 [dependencies]
 embedded-storage = "0.3"
+tca9539 = "0.2"
 menu = "0.3"
 cortex-m = { version = "0.7.7", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = { version = "0.7", features = ["device"] }

--- a/src/hardware/pounder/io_expander.rs
+++ b/src/hardware/pounder/io_expander.rs
@@ -1,0 +1,126 @@
+use super::{Error, GpioPin};
+use crate::hardware::I2c1Proxy;
+
+pub enum IoExpander {
+    Mcp23017(mcp230xx::Mcp230xx<I2c1Proxy, mcp230xx::Mcp23017>),
+    Pca9539(tca9539::Pca9539<I2c1Proxy>),
+}
+
+impl From<GpioPin> for mcp230xx::Mcp23017 {
+    fn from(x: GpioPin) -> Self {
+        match x {
+            GpioPin::Led4Green => Self::A0,
+            GpioPin::Led5Red => Self::A1,
+            GpioPin::Led6Green => Self::A2,
+            GpioPin::Led7Red => Self::A3,
+            GpioPin::Led8Green => Self::A4,
+            GpioPin::Led9Red => Self::A5,
+            GpioPin::AttLe0 => Self::B0,
+            GpioPin::AttLe1 => Self::B1,
+            GpioPin::AttLe2 => Self::B2,
+            GpioPin::AttLe3 => Self::B3,
+            GpioPin::AttRstN => Self::B5,
+            GpioPin::OscEnN => Self::B6,
+            GpioPin::ExtClkSel => Self::B7,
+        }
+    }
+}
+
+impl From<GpioPin> for tca9539::Pin {
+    fn from(x: GpioPin) -> Self {
+        match x {
+            GpioPin::Led4Green => Self::P00,
+            GpioPin::Led5Red => Self::P01,
+            GpioPin::Led6Green => Self::P02,
+            GpioPin::Led7Red => Self::P03,
+            GpioPin::Led8Green => Self::P04,
+            GpioPin::Led9Red => Self::P05,
+            GpioPin::AttLe0 => Self::P10,
+            GpioPin::AttLe1 => Self::P11,
+            GpioPin::AttLe2 => Self::P12,
+            GpioPin::AttLe3 => Self::P13,
+            GpioPin::AttRstN => Self::P15,
+            GpioPin::OscEnN => Self::P16,
+            GpioPin::ExtClkSel => Self::P17,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum Level {
+    High,
+    Low,
+}
+
+impl Into<tca9539::Level> for Level {
+    fn into(self) -> tca9539::Level {
+        match self {
+            Level::Low => tca9539::Level::Low,
+            Level::High => tca9539::Level::High,
+        }
+    }
+}
+
+impl Into<mcp230xx::Level> for Level {
+    fn into(self) -> mcp230xx::Level {
+        match self {
+            Level::Low => mcp230xx::Level::Low,
+            Level::High => mcp230xx::Level::High,
+        }
+    }
+}
+
+pub enum Direction {
+    Output,
+    Input,
+}
+
+impl Into<tca9539::Direction> for Direction {
+    fn into(self) -> tca9539::Direction {
+        match self {
+            Direction::Output => tca9539::Direction::Output,
+            Direction::Input => tca9539::Direction::Input,
+        }
+    }
+}
+
+impl Into<mcp230xx::Direction> for Direction {
+    fn into(self) -> mcp230xx::Direction {
+        match self {
+            Direction::Output => mcp230xx::Direction::Output,
+            Direction::Input => mcp230xx::Direction::Input,
+        }
+    }
+}
+
+impl IoExpander {
+    pub fn set_direction(
+        &mut self,
+        pin: GpioPin,
+        direction: Direction,
+    ) -> Result<(), Error> {
+        match self {
+            Self::Mcp23017(expander) => expander
+                .set_direction(pin.into(), direction.into())
+                .map_err(|_| Error::I2c),
+            Self::Pca9539(expander) => expander
+                .set_direction(pin.into(), direction.into())
+                .map_err(|_| Error::I2c),
+        }
+    }
+
+    pub fn set_level(
+        &mut self,
+        pin: GpioPin,
+        level: Level,
+    ) -> Result<(), Error> {
+        match self {
+            Self::Mcp23017(expander) => expander
+                .set_gpio(pin.into(), level.into())
+                .map_err(|_| Error::I2c),
+            Self::Pca9539(expander) => expander
+                .set_level(pin.into(), level.into())
+                .map_err(|_| Error::I2c),
+        }
+    }
+}

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -813,8 +813,14 @@ pub fn setup(
             shared_bus::new_atomic_check!(hal::i2c::I2c<hal::stm32::I2C1> = i2c1).unwrap()
         };
 
-        let io_expander =
-            mcp230xx::Mcp230xx::new_default(i2c1.acquire_i2c()).unwrap();
+        let io_expander = {
+            match mcp230xx::Mcp230xx::new_default(i2c1.acquire_i2c()) {
+                Ok(expander) => pounder::IoExpander::Mcp23017(expander),
+                _ => pounder::IoExpander::Pca9539(
+                    tca9539::Pca9539::new_default(i2c1.acquire_i2c()).unwrap(),
+                ),
+            }
+        };
 
         let temp_sensor =
             lm75::Lm75::new(i2c1.acquire_i2c(), lm75::Address::default());


### PR DESCRIPTION
Fixes #804 by adding pounder v1.2 support by updating the code to use one of the two GPIO expander options.

@jordens I don't have a pounder to test this on, and I think you may have one? Would you be willing to take a look?

Also, it would be helpful to know if more than the GPIO expander changed - I haven't found anything else yet.