### PR TITLE
Adding metadata and persistent panic info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         # keep MSRV in sync in ci.yaml and Cargo.toml
-        toolchain: [stable, '1.65.0']
+        toolchain: [stable, '1.66.0']
         features: ['']
         continue-on-error: [false]
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ console.
 
 ### Changed
 * Broker is no longer configured at compile time, but is maintained in device memory
+* MSRV bumped to v1.66
 
 ## [0.9.0](https://github.com/quartiq/stabilizer/compare/v0.8.1...v0.9.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 * Serial terminal is available on USB for settings configurations
 * Reboot to DFU support added via the serial terminal for remote bootloading
-* The `alive` topic now contains metadata about the compiler, firmware, and hardware similar to
+* The `meta` topic now contains metadata about the compiler, firmware, and hardware similar to
 Booster
 * Panic information is now persisted after reboot and available via telemetry and the USB serial
 console.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 * Serial terminal is available on USB for settings configurations
 * Reboot to DFU support added via the serial terminal for remote bootloading
+* The `alive` topic now contains metadata about the compiler, firmware, and hardware similar to
+Booster
+* Panic information is now persisted after reboot and available via telemetry and the USB serial
+console.
 
 ### Changed
 * Broker is no longer configured at compile time, but is maintained in device memory

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "built"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d17f4d6e4dc36d1a02fbedc2753a096848e7c1b0772f7654eab8e2c927dd53"
+dependencies = [
+ "git2",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +128,16 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "jobserver",
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -284,6 +303,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fugit"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +352,19 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "git2"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -375,6 +416,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "idsp"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,10 +453,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "jobserver"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.16.1+1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libz-sys"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "lm75"
@@ -677,10 +767,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "panic-persist"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32bb382689ecd2c4d2d4df9fd56700ba8d43b7b31cca11018cc0e6f8aef39fd5"
+dependencies = [
+ "cortex-m 0.7.7",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "portable-atomic"
@@ -987,6 +1098,8 @@ version = "0.9.0"
 dependencies = [
  "ad9959",
  "bbqueue",
+ "bit_field",
+ "built",
  "cortex-m 0.7.7",
  "cortex-m-rt",
  "cortex-m-rtic",
@@ -1005,6 +1118,7 @@ dependencies = [
  "mono-clock",
  "mutex-trait",
  "num_enum 0.7.1",
+ "panic-persist",
  "paste",
  "postcard",
  "rand_core",
@@ -1108,6 +1222,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,10 +1249,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "usb-device"
@@ -1139,7 +1294,7 @@ dependencies = [
 [[package]]
 name = "usbd-serial"
 version = "0.2.0"
-source = "git+https://github.com/rust-embedded-community/usbd-serial#6611dc092822c60b4482e28aab2fe084c1756410"
+source = "git+https://github.com/rust-embedded-community/usbd-serial?rev=096742c1c480f6f63c1a936a3c23ede7993c624d#096742c1c480f6f63c1a936a3c23ede7993c624d"
 dependencies = [
  "embedded-hal",
  "embedded-io",
@@ -1158,6 +1313,12 @@ name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ documentation = "https://docs.rs/stabilizer/"
 edition = "2021"
 # keep MSRV in sync in ci.yaml and Cargo.toml
 rust-version = "1.65"
+build = "build.rs"
 exclude = [
 	".gitignore",
 	"doc/",
@@ -34,6 +35,7 @@ default-target = "thumbv7em-none-eabihf"
 members = ["ad9959", "serial-settings"]
 
 [dependencies]
+panic-persist = { version = "0.3", features = ["utf8", "custom-panic-handler"] }
 sequential-storage = "0.6"
 embedded-io = "0.6"
 embedded-storage = "0.3"
@@ -71,6 +73,10 @@ miniconf = "0.9.0"
 smoltcp-nal = { version = "0.4.1", features = ["shared-stack"]}
 bbqueue = "0.5"
 postcard = "1"
+bit_field = "0.10.2"
+
+[build-dependencies]
+built = { version = "0.7", features = ["git2"], default-features = false }
 
 [dependencies.stm32h7xx-hal]
 version = "0.15.1"
@@ -80,6 +86,7 @@ features = ["stm32h743v", "rt", "ethernet", "xspi", "usb_hs"]
 
 [patch.crates-io.usbd-serial]
 git = "https://github.com/rust-embedded-community/usbd-serial"
+rev = "096742c1c480f6f63c1a936a3c23ede7993c624d"
 
 [features]
 nightly = [ ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 documentation = "https://docs.rs/stabilizer/"
 edition = "2021"
 # keep MSRV in sync in ci.yaml and Cargo.toml
-rust-version = "1.65"
+rust-version = "1.66"
 build = "build.rs"
 exclude = [
 	".gitignore",

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
 fn main() {
+    built::write_built_file()
+        .expect("Failed to acquire build-time information");
     println!("cargo:rerun-if-changed=memory.x");
 }

--- a/memory.x
+++ b/memory.x
@@ -10,10 +10,16 @@ MEMORY
   RAM_B  (rwx) : ORIGIN = 0x38800000, LENGTH = 4K
   FLASH  (rx)  : ORIGIN = 0x08000000, LENGTH = 1024K
   FLASH1 (rx)  : ORIGIN = 0x08100000, LENGTH = 1024K
-  BOOTFLAG_RAM: ORIGIN = 0x2001FC00, LENGTH = 1K
+  PERSISTENT_RAM: ORIGIN = 0x2001FC00, LENGTH = 1K
 }
 
-_bootflag = ORIGIN(BOOTFLAG_RAM);
+/*
+ * Persistent memory has a u32 bootflag at the beginning and then the remainder is used for
+ * persisting panic information between boots.
+ */
+_bootflag = ORIGIN(PERSISTENT_RAM);
+_panic_dump_start = ORIGIN(PERSISTENT_RAM) + 4;
+_panic_dump_end = ORIGIN(PERSISTENT_RAM) + LENGTH(PERSISTENT_RAM) - 4;
 
 SECTIONS {
   .axisram (NOLOAD) : ALIGN(8) {

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -225,6 +225,7 @@ mod app {
             env!("CARGO_BIN_NAME"),
             &settings.broker,
             &settings.id,
+            stabilizer.metadata,
         );
 
         let generator = network.configure_streaming(StreamFormat::AdcDacData);

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -265,6 +265,7 @@ mod app {
             env!("CARGO_BIN_NAME"),
             &settings.broker,
             &settings.id,
+            stabilizer.metadata,
         );
 
         let generator = network.configure_streaming(StreamFormat::AdcDacData);

--- a/src/hardware/metadata.rs
+++ b/src/hardware/metadata.rs
@@ -24,7 +24,6 @@ impl ApplicationMetadata {
     ///
     /// # Args
     /// * `hardware_version` - The hardware version detected.
-    /// * `phy` - The identifier of the detected ethernet PHY.
     ///
     /// # Returns
     /// A reference to the global metadata.

--- a/src/hardware/metadata.rs
+++ b/src/hardware/metadata.rs
@@ -1,0 +1,42 @@
+use crate::hardware::HardwareVersion;
+use serde::Serialize;
+
+mod build_info {
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
+#[derive(Serialize)]
+pub struct ApplicationMetadata {
+    pub firmware_version: &'static str,
+    pub rust_version: &'static str,
+    pub profile: &'static str,
+    pub git_dirty: bool,
+    pub features: &'static str,
+    pub panic_info: &'static str,
+    pub hardware_version: HardwareVersion,
+}
+
+impl ApplicationMetadata {
+    /// Construct the global metadata.
+    ///
+    /// # Note
+    /// This may only be called once.
+    ///
+    /// # Args
+    /// * `hardware_version` - The hardware version detected.
+    /// * `phy` - The identifier of the detected ethernet PHY.
+    ///
+    /// # Returns
+    /// A reference to the global metadata.
+    pub fn new(version: HardwareVersion) -> &'static ApplicationMetadata {
+        cortex_m::singleton!(: ApplicationMetadata = ApplicationMetadata {
+            firmware_version: build_info::GIT_VERSION.unwrap_or("Unspecified"),
+            rust_version: build_info::RUSTC_VERSION,
+            profile: build_info::PROFILE,
+            git_dirty: build_info::GIT_DIRTY.unwrap_or(false),
+            features: build_info::FEATURES_STR,
+            hardware_version: version,
+            panic_info: panic_persist::get_panic_message_utf8().unwrap_or("None"),
+        }).unwrap()
+    }
+}

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -12,6 +12,7 @@ pub mod design_parameters;
 mod eeprom;
 pub mod flash;
 pub mod input_stamper;
+pub mod metadata;
 pub mod platform;
 pub mod pounder;
 pub mod setup;
@@ -86,6 +87,53 @@ pub type I2c1Proxy =
 pub type SerialTerminal =
     serial_settings::Runner<'static, crate::settings::SerialSettingsPlatform>;
 
+pub enum HardwareVersion {
+    Rev1_0,
+    Rev1_1,
+    Rev1_2,
+    Rev1_3,
+    Unknown(u8),
+}
+
+impl From<u8> for HardwareVersion {
+    fn from(bitfield: u8) -> Self {
+        match bitfield {
+            0b000 => HardwareVersion::Rev1_0,
+            0b001 => HardwareVersion::Rev1_1,
+            0b010 => HardwareVersion::Rev1_2,
+            0b011 => HardwareVersion::Rev1_3,
+            other => HardwareVersion::Unknown(other),
+        }
+    }
+}
+
+impl core::fmt::Display for HardwareVersion {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            HardwareVersion::Rev1_0 => write!(f, "v1.0"),
+            HardwareVersion::Rev1_1 => write!(f, "v1.1"),
+            HardwareVersion::Rev1_2 => write!(f, "v1.2"),
+            HardwareVersion::Rev1_3 => write!(f, "v1.3"),
+            HardwareVersion::Unknown(other) => {
+                write!(f, "Unknown ({:#b})", other)
+            }
+        }
+    }
+}
+
+impl serde::Serialize for HardwareVersion {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        use core::fmt::Write;
+
+        let mut version_string: heapless::String<32> = heapless::String::new();
+        write!(&mut version_string, "{}", self).unwrap();
+        serializer.serialize_str(&version_string)
+    }
+}
+
 #[inline(never)]
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
@@ -114,6 +162,8 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
         channel.set_mode(ChannelMode::BlockIfFull);
         writeln!(channel, "{info}").ok();
     }
+
+    panic_persist::report_panic_info(info);
 
     // Abort
     asm::udf();

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -13,7 +13,10 @@ pub mod data_stream;
 pub mod network_processor;
 pub mod telemetry;
 
-use crate::hardware::{EthernetPhy, NetworkManager, NetworkStack, SystemTimer};
+use crate::hardware::{
+    metadata::ApplicationMetadata, EthernetPhy, NetworkManager, NetworkStack,
+    SystemTimer,
+};
 use data_stream::{DataStream, FrameGenerator};
 use network_processor::NetworkProcessor;
 use telemetry::TelemetryClient;
@@ -85,6 +88,8 @@ where
     /// * `clock` - A `SystemTimer` implementing `Clock`.
     /// * `app` - The name of the application.
     /// * `broker` - The domain name of the MQTT broker to use.
+    /// * `id` - The MQTT client ID base to use.
+    /// * `metadata` - The application metadata
     ///
     /// # Returns
     /// A new struct of network users.
@@ -95,6 +100,7 @@ where
         app: &str,
         broker: &str,
         id: &str,
+        metadata: &'static ApplicationMetadata,
     ) -> Self {
         let stack_manager =
             cortex_m::singleton!(: NetworkManager = NetworkManager::new(stack))
@@ -144,7 +150,7 @@ where
                 .unwrap(),
         );
 
-        let telemetry = TelemetryClient::new(mqtt, &prefix);
+        let telemetry = TelemetryClient::new(mqtt, &prefix, metadata);
 
         let (generator, stream) =
             data_stream::setup_streaming(stack_manager.acquire_stack());

--- a/src/net/telemetry.rs
+++ b/src/net/telemetry.rs
@@ -193,7 +193,7 @@ impl<T: Serialize> TelemetryClient<T> {
             } = self;
 
             let mut topic = self.prefix.clone();
-            topic.push_str("/alive/meta").unwrap();
+            topic.push_str("/meta").unwrap();
 
             if mqtt
                 .client()


### PR DESCRIPTION
Fixes #821 by using generally the same logic as Booster to persist panic information into RAM for later inspection. Also adds the `/alive` topic info that Booster has:
![image](https://github.com/quartiq/stabilizer/assets/8771450/82f8d122-0816-4bac-a79e-dff65b090718)

```
> platform service
Version             : v0.9.0-74-gaccf844 [release]
Hardware Revision   : v1.1
Rustc Version       : rustc 1.74.0 (79e9716c9 2023-11-13)
Features            :
Panic Info          : None

>
```