### PR TITLE
Fixing USB enumeration issues on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ console.
   See also the `iir_coefficients` Python CLI implementation.
 * Bumped MSRV 1.66.0 -> 1.66.1
 
+### Fixed
+* Fixed an issue where the device would rarely not enumerate on Windows
+
 ## [0.9.0](https://github.com/quartiq/stabilizer/compare/v0.8.1...v0.9.0)
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,15 +717,6 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
-dependencies = [
- "num_enum_derive 0.6.1",
-]
-
-[[package]]
-name = "num_enum"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
@@ -742,17 +733,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -1295,11 +1275,11 @@ dependencies = [
 [[package]]
 name = "usb-device"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73e438f527e567fb3982f2370967821fab4f5aea84c42e218a211dd2002b6a2"
+source = "git+https://github.com/rust-embedded-community/usb-device?branch=feature/usb-tracing#af340092074123540098da6821d10fa64dbc9e9f"
 dependencies = [
- "heapless 0.7.17",
- "num_enum 0.6.1",
+ "heapless 0.8.0",
+ "log",
+ "num_enum 0.7.2",
  "portable-atomic",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,11 +1275,9 @@ dependencies = [
 [[package]]
 name = "usb-device"
 version = "0.3.1"
-source = "git+https://github.com/rust-embedded-community/usb-device?branch=feature/usb-tracing#af340092074123540098da6821d10fa64dbc9e9f"
+source = "git+https://github.com/vitalyvb/usb-device#7c998d88fb2b29316f971a8fc96c7a57d663b6ee"
 dependencies = [
  "heapless 0.8.0",
- "log",
- "num_enum 0.7.2",
  "portable-atomic",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,7 +1275,7 @@ dependencies = [
 [[package]]
 name = "usb-device"
 version = "0.3.1"
-source = "git+https://github.com/vitalyvb/usb-device#7c998d88fb2b29316f971a8fc96c7a57d663b6ee"
+source = "git+https://github.com/rust-embedded-community/usb-device#2dbba84d71797bc12d964b1b936a7c464777c864"
 dependencies = [
  "heapless 0.8.0",
  "portable-atomic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ embedded-io = "0.6"
 embedded-storage = "0.3"
 cortex-m = { version = "0.7.7", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = { version = "0.7", features = ["device"] }
-log = { version = "0.4", features = ["max_level_trace", "release_max_level_trace"] }
+log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"] }
 rtt-target = "0.3"
 serde = { version = "1.0", features = ["derive"], default-features = false }
 serde-json-core = "0.5"
@@ -66,7 +66,7 @@ enum-iterator = "1.4.1"
 rand_xorshift = "0.3.0"
 rand_core = "0.6.4"
 minimq = "0.8.0"
-usb-device = { git = "https://github.com/rust-embedded-community/usb-device", branch = "feature/usb-tracing", features = ["log"] }
+usb-device = "0.3"
 usbd-serial = "0.2"
 # Keep this synced with the miniconf version in py/setup.py
 miniconf = "0.9.0"
@@ -78,7 +78,6 @@ bit_field = "0.10.2"
 
 [patch.crates-io.usb-device]
 git = "https://github.com/rust-embedded-community/usb-device"
-branch = "feature/usb-tracing"
 
 [build-dependencies]
 built = { version = "0.7", features = ["git2"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ embedded-io = "0.6"
 embedded-storage = "0.3"
 cortex-m = { version = "0.7.7", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = { version = "0.7", features = ["device"] }
-log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"] }
+log = { version = "0.4", features = ["max_level_trace", "release_max_level_trace"] }
 rtt-target = "0.3"
 serde = { version = "1.0", features = ["derive"], default-features = false }
 serde-json-core = "0.5"
@@ -66,7 +66,7 @@ enum-iterator = "1.4.1"
 rand_xorshift = "0.3.0"
 rand_core = "0.6.4"
 minimq = "0.8.0"
-usb-device = "0.3.0"
+usb-device = { git = "https://github.com/rust-embedded-community/usb-device", branch = "feature/usb-tracing", features = ["log"] }
 usbd-serial = "0.2"
 # Keep this synced with the miniconf version in py/setup.py
 miniconf = "0.9.0"
@@ -75,6 +75,10 @@ smoltcp-nal = { version = "0.4.1", features = ["shared-stack"]}
 bbqueue = "0.5"
 postcard = "1"
 bit_field = "0.10.2"
+
+[patch.crates-io.usb-device]
+git = "https://github.com/rust-embedded-community/usb-device"
+branch = "feature/usb-tracing"
 
 [build-dependencies]
 built = { version = "0.7", features = ["git2"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ enum-iterator = "1.4.1"
 rand_xorshift = "0.3.0"
 rand_core = "0.6.4"
 minimq = "0.8.0"
-usb-device = "0.3"
+usb-device = "0.3.0"
 usbd-serial = "0.2"
 # Keep this synced with the miniconf version in py/setup.py
 miniconf = "0.9.0"

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -244,12 +244,11 @@ pub fn setup(
         }
 
         static LOGGER: rtt_logger::RTTLogger =
-            rtt_logger::RTTLogger::new(log::LevelFilter::Trace);
+            rtt_logger::RTTLogger::new(log::LevelFilter::Info);
         log::set_logger(&LOGGER)
             .map(|()| log::set_max_level(log::LevelFilter::Trace))
             .unwrap();
         log::info!("Starting");
-        log::trace!("Tracing");
     }
 
     // Check for a reboot to DFU before doing any system configuration.

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -244,11 +244,12 @@ pub fn setup(
         }
 
         static LOGGER: rtt_logger::RTTLogger =
-            rtt_logger::RTTLogger::new(log::LevelFilter::Info);
+            rtt_logger::RTTLogger::new(log::LevelFilter::Trace);
         log::set_logger(&LOGGER)
             .map(|()| log::set_max_level(log::LevelFilter::Trace))
             .unwrap();
         log::info!("Starting");
+        log::trace!("Tracing");
     }
 
     // Check for a reboot to DFU before doing any system configuration.


### PR DESCRIPTION
Fixes #817 by patching to a fixed `usb-device` version. I'm planning on re-releasing `usb-device` as 0.3.2 shortly, so we can hold off until then if desired as well.