### PR TITLE
Fixing USB interfaces

### DIFF
--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -479,7 +479,7 @@ mod app {
 
     #[task(priority = 1, shared=[usb], local=[usb_terminal])]
     async fn usb(mut c: usb::Context) {
-        {
+        loop {
             // Handle the USB serial terminal.
             c.shared.usb.lock(|usb| {
                 usb.poll(&mut [c

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -314,6 +314,7 @@ mod app {
         telemetry::spawn().unwrap();
         ethernet_link::spawn().unwrap();
         start::spawn().unwrap();
+        usb::spawn().unwrap();
 
         // Start recording digital input timestamps.
         stabilizer.timestamp_timer.start();


### PR DESCRIPTION
This fixes a few issues with USB on the `lockin` and `dual-iir` apps. It looks like some issues snuck in while converting to RTIC 2.

I've also updated things in the serial backend to work with 64 byte path buffers in preparation for https://github.com/quartiq/stabilizer/pull/857