### PR TITLE
Add support for saving the active configuration to flash

### DIFF
--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -23,7 +23,7 @@ Power Stabilizer through **exactly one** of the following mechanisms.
 
 ## USB Configuration
 
-The USB port can be used to bootstrap Stabilizer and configure all internal settings. This is useful
+The USB port can be used to bootstrap Stabilizer and configure initial settings. This is useful
 either when first configuring the MQTT connection or when operating Stabilizer in standalone mode
 (i.e. without an ethernet connection or an MQTT broker).
 
@@ -33,20 +33,19 @@ provides a simple, easy-to-use terminal emulator:
 python -m serial <port>
 ```
 
-Once you have opened the port, you can use the provided menu to update any of Stabilizers runtime
-settings. All settings configured via the USB interface are only applied when Stabilizer first boots
-up. Any modifications that occur after boot over the MQTT interface will occur after the initial
-settings configured via USB.
+Once you have opened the port, you can use the provided menu to update any of Stabilizers settings.
+All settings configured via the USB interface are only applied when Stabilizer first boots up.
 
-> **Note:** Settings configured via USB do not take immediat effect. Instead, they will apply after
+> **Note:** Settings configured via USB do not take immediate effect. Instead, they will apply after
 > the device is rebooted.
 
 > **Note:** Settings configured via USB are only initial settings. Any modifications
 > that occur after startup (i.e. via MQTT) will take precedent over those configured via USB. MQTT
 > settings can only be persisted or retained via the MQTT broker.
 
-> **Note:** Saving settings via the USB port only saves the initial settings. It does not take into
-> account the current operational settings that may have been applied via MQTT.
+> **Note:** Saving settings through the USB interface only saves the initial settings. It does not
+> take into account the current operational settings that may have been applied via MQTT. To save
+> the active settings, use the `platform save-active` command.
 
 ## Network and DHCP
 

--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -43,9 +43,9 @@ All settings configured via the USB interface are only applied when Stabilizer f
 > that occur after startup (i.e. via MQTT) will take precedent over those configured via USB. MQTT
 > settings can only be persisted or retained via the MQTT broker.
 
-> **Note:** Saving settings through the USB interface only saves the initial settings. It does not
-> take into account the current operational settings that may have been applied via MQTT. To save
-> the active settings, use the `platform save-active` command.
+> **Note:** Modifying settings through the USB interface only modifies the initial settings. It does
+> not take into account the current operational settings that may have been applied via MQTT. To
+> save the active settings, use the `platform save-active` command.
 
 ## Network and DHCP
 

--- a/book/src/usage.md
+++ b/book/src/usage.md
@@ -116,3 +116,10 @@ Livestreamed data is sent with "best effort" - it's possible that data may be lo
 network congestion or by Stabilizer.
 
 Refer to the the respective [application documentation](overview.md#applications) for more information.
+
+# USB Port
+Stabilizer exposes a USB port to interact with and configure the device without an MQTT connection.
+
+Refer to the [setup](setup.md) document around usage of this interface. The USB interface can also
+be used to save the currently-active settings (those configured via MQTT) to device memory so that
+they are applied when the device reboots by using the `platform save-active` command.

--- a/src/bin/dual-iir.rs
+++ b/src/bin/dual-iir.rs
@@ -462,7 +462,10 @@ mod app {
         c.shared.settings.lock(|current| *current = settings);
 
         c.shared.usb_terminal.lock(|terminal| {
-            terminal.platform_mut().active_settings.dual_iir = settings
+            terminal.platform_mut().active_settings = Settings {
+                dual_iir: settings,
+                ..terminal.settings().clone()
+            }
         });
 
         c.local.afes.0.set_gain(settings.afe[0]);

--- a/src/bin/lockin.rs
+++ b/src/bin/lockin.rs
@@ -519,7 +519,10 @@ mod app {
         c.shared.settings.lock(|current| *current = settings);
 
         c.shared.usb_terminal.lock(|terminal| {
-            terminal.platform_mut().active_settings.lockin = settings
+            terminal.platform_mut().active_settings = Settings {
+                lockin: settings,
+                ..terminal.settings().clone()
+            }
         });
 
         c.local.afes.0.set_gain(settings.afe[0]);

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -1157,6 +1157,7 @@ where
                     usb_serial,
                 ),
                 storage: flash,
+                active_settings: settings.clone(),
                 settings,
                 metadata,
             },


### PR DESCRIPTION
This PR fixes #859 by adding a platform command to save the active running settings to flash.

Below is output during testing. CH0 is configured as a PID with Kp=2 via MQTT and then the `save-active` command was used to update the flash-based settings.
```
> list
/dual_iir/afe/0: "G1" [default: "G1"]
/dual_iir/afe/1: "G1" [default: "G1"]
/dual_iir/iir_ch/0/0: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0} [default: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0}]
/dual_iir/iir_ch/1/0: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0} [default: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0}]
/dual_iir/allow_hold: false [default: false]
/dual_iir/force_hold: false [default: false]
/dual_iir/telemetry_period: 10 [default: 10]
/dual_iir/stream_target: {"ip":[0,0,0,0],"port":0} [default: {"ip":[0,0,0,0],"port":0}]
/dual_iir/signal_generator/0/signal: "Cosine" [default: "Cosine"]
/dual_iir/signal_generator/0/frequency: 1000.0 [default: 1000.0]
/dual_iir/signal_generator/0/symmetry: 0.5 [default: 0.5]
/dual_iir/signal_generator/0/amplitude: 0.0 [default: 0.0]
/dual_iir/signal_generator/0/phase: 0.0 [default: 0.0]
/dual_iir/signal_generator/1/signal: "Cosine" [default: "Cosine"]
/dual_iir/signal_generator/1/frequency: 1000.0 [default: 1000.0]
/dual_iir/signal_generator/1/symmetry: 0.5 [default: 0.5]
/dual_iir/signal_generator/1/amplitude: 0.0 [default: 0.0]
/dual_iir/signal_generator/1/phase: 0.0 [default: 0.0]
/net/broker: "mqtt" [default: "mqtt"]
/net/id: "04-91-62-d2-a8-6f" [default: "04-91-62-d2-a8-6f"]
/net/ip: "0.0.0.0" [default: "0.0.0.0"]

> platform save-active
Currently active settings saved.

> list
/dual_iir/afe/0: "G1" [default: "G1"]
/dual_iir/afe/1: "G1" [default: "G1"]
/dual_iir/iir_ch/0/0: {"ba":[2.0,0.0,0.0,-0.0,-0.0],"u":0.0,"min":-32767.0,"max":32767.0} [default: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0}]
/dual_iir/iir_ch/1/0: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0} [default: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0}]
/dual_iir/allow_hold: false [default: false]
/dual_iir/force_hold: false [default: false]
/dual_iir/telemetry_period: 10 [default: 10]
/dual_iir/stream_target: {"ip":[0,0,0,0],"port":0} [default: {"ip":[0,0,0,0],"port":0}]
/dual_iir/signal_generator/0/signal: "Cosine" [default: "Cosine"]
/dual_iir/signal_generator/0/frequency: 1000.0 [default: 1000.0]
/dual_iir/signal_generator/0/symmetry: 0.5 [default: 0.5]
/dual_iir/signal_generator/0/amplitude: 0.0 [default: 0.0]
/dual_iir/signal_generator/0/phase: 0.0 [default: 0.0]
/dual_iir/signal_generator/1/signal: "Cosine" [default: "Cosine"]
/dual_iir/signal_generator/1/frequency: 1000.0 [default: 1000.0]
/dual_iir/signal_generator/1/symmetry: 0.5 [default: 0.5]
/dual_iir/signal_generator/1/amplitude: 0.0 [default: 0.0]
/dual_iir/signal_generator/1/phase: 0.0 [default: 0.0]
/net/broker: "mqtt" [default: "mqtt"]
/net/id: "04-91-62-d2-a8-6f" [default: "04-91-62-d2-a8-6f"]
/net/ip: "0.0.0.0" [default: "0.0.0.0"]
```