### PR TITLE
Adding support for clearing individual settings

### DIFF
--- a/serial-settings/src/lib.rs
+++ b/serial-settings/src/lib.rs
@@ -196,7 +196,7 @@ impl<'a, P: Platform<Y>, const Y: usize> Context<'a, P, Y> {
 
         match context.platform.save(context.buffer) {
             Ok(_) => {
-                writeln!(context, "Clear successful.")
+                writeln!(context, "Settings saved. Reboot device (`platform reboot`) to apply.")
             }
             Err(e) => {
                 writeln!(context, "Failed to clear settings: {e:?}")

--- a/serial-settings/src/lib.rs
+++ b/serial-settings/src/lib.rs
@@ -161,14 +161,42 @@ impl<'a, P: Platform<Y>, const Y: usize> Context<'a, P, Y> {
 
     fn handle_clear(
         _menu: &menu::Menu<Self>,
-        _item: &menu::Item<Self>,
-        _args: &[&str],
+        item: &menu::Item<Self>,
+        args: &[&str],
         context: &mut Self,
     ) {
-        context.platform.settings_mut().reset();
+        if let Some(key) = menu::argument_finder(item, args, "item").unwrap() {
+            let mut defaults = context.platform.settings().clone();
+            defaults.reset();
+
+            let len = match defaults.get_json(key, context.buffer) {
+                Err(e) => {
+                    writeln!(context, "Failed to clear `{key}`: {e:?}")
+                        .unwrap();
+                    return;
+                }
+
+                Ok(len) => len,
+            };
+
+            if let Err(e) = context
+                .platform
+                .settings_mut()
+                .set_json(key, &context.buffer[..len])
+            {
+                writeln!(context, "Failed to update {key}: {e:?}").unwrap();
+                return;
+            }
+
+            writeln!(context, "{key} cleared to default").unwrap();
+        } else {
+            context.platform.settings_mut().reset();
+            writeln!(context, "All settings cleared").unwrap();
+        }
+
         match context.platform.save(context.buffer) {
             Ok(_) => {
-                writeln!(context, "Settings cleared to defaults and saved.")
+                writeln!(context, "Clear successful.")
             }
             Err(e) => {
                 writeln!(context, "Failed to clear settings: {e:?}")
@@ -278,7 +306,12 @@ impl<'a, P: Platform<Y>, const Y: usize> Context<'a, P, Y> {
                 help: Some("Clear the device settings to default values."),
                 item_type: menu::ItemType::Callback {
                     function: Self::handle_clear,
-                    parameters: &[]
+                    parameters: &[
+                        menu::Parameter::Optional {
+                            parameter_name: "item",
+                            help: Some("The name of the setting to clear."),
+                        },
+                    ]
                 },
             },
             &menu::Item {


### PR DESCRIPTION
This PR fixes #860 by adding support for clearing individual settings via USB.

I tested this by modifying `/net/ip` and `/net/broker` individually and then cleared each one in sequence, verifying that the other was not reset unintentionally.
```
> list
/dual_iir/afe/0: "G1" [default: "G1"]
/dual_iir/afe/1: "G1" [default: "G1"]
/dual_iir/iir_ch/0/0: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0} [default: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0}]
/dual_iir/iir_ch/1/0: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0} [default: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0}]
/dual_iir/allow_hold: false [default: false]
/dual_iir/force_hold: false [default: false]
/dual_iir/telemetry_period: 10 [default: 10]
/dual_iir/stream_target: {"ip":[0,0,0,0],"port":0} [default: {"ip":[0,0,0,0],"port":0}]
/dual_iir/signal_generator/0/signal: "Cosine" [default: "Cosine"]
/dual_iir/signal_generator/0/frequency: 1000.0 [default: 1000.0]
/dual_iir/signal_generator/0/symmetry: 0.5 [default: 0.5]
/dual_iir/signal_generator/0/amplitude: 0.0 [default: 0.0]
/dual_iir/signal_generator/0/phase: 0.0 [default: 0.0]
/dual_iir/signal_generator/1/signal: "Cosine" [default: "Cosine"]
/dual_iir/signal_generator/1/frequency: 1000.0 [default: 1000.0]
/dual_iir/signal_generator/1/symmetry: 0.5 [default: 0.5]
/dual_iir/signal_generator/1/amplitude: 0.0 [default: 0.0]
/dual_iir/signal_generator/1/phase: 0.0 [default: 0.0]
/net/broker: "mqtt" [default: "mqtt"]
/net/id: "04-91-62-d2-a8-6f" [default: "04-91-62-d2-a8-6f"]
/net/ip: "0.0.0.0" [default: "0.0.0.0"]

> set /net/ip "haha"
Settings saved. Reboot device (`platform reboot`) to apply.

> list
/dual_iir/afe/0: "G1" [default: "G1"]
/dual_iir/afe/1: "G1" [default: "G1"]
/dual_iir/iir_ch/0/0: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0} [default: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0}]
/dual_iir/iir_ch/1/0: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0} [default: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0}]
/dual_iir/allow_hold: false [default: false]
/dual_iir/force_hold: false [default: false]
/dual_iir/telemetry_period: 10 [default: 10]
/dual_iir/stream_target: {"ip":[0,0,0,0],"port":0} [default: {"ip":[0,0,0,0],"port":0}]
/dual_iir/signal_generator/0/signal: "Cosine" [default: "Cosine"]
/dual_iir/signal_generator/0/frequency: 1000.0 [default: 1000.0]
/dual_iir/signal_generator/0/symmetry: 0.5 [default: 0.5]
/dual_iir/signal_generator/0/amplitude: 0.0 [default: 0.0]
/dual_iir/signal_generator/0/phase: 0.0 [default: 0.0]
/dual_iir/signal_generator/1/signal: "Cosine" [default: "Cosine"]
/dual_iir/signal_generator/1/frequency: 1000.0 [default: 1000.0]
/dual_iir/signal_generator/1/symmetry: 0.5 [default: 0.5]
/dual_iir/signal_generator/1/amplitude: 0.0 [default: 0.0]
/dual_iir/signal_generator/1/phase: 0.0 [default: 0.0]
/net/broker: "mqtt" [default: "mqtt"]
/net/id: "04-91-62-d2-a8-6f" [default: "04-91-62-d2-a8-6f"]
/net/ip: "haha" [default: "0.0.0.0"]

> set /net/broker "test"
Settings saved. Reboot device (`platform reboot`) to apply.

> list
/dual_iir/afe/0: "G1" [default: "G1"]
/dual_iir/afe/1: "G1" [default: "G1"]
/dual_iir/iir_ch/0/0: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0} [default: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0}]
/dual_iir/iir_ch/1/0: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0} [default: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0}]
/dual_iir/allow_hold: false [default: false]
/dual_iir/force_hold: false [default: false]
/dual_iir/telemetry_period: 10 [default: 10]
/dual_iir/stream_target: {"ip":[0,0,0,0],"port":0} [default: {"ip":[0,0,0,0],"port":0}]
/dual_iir/signal_generator/0/signal: "Cosine" [default: "Cosine"]
/dual_iir/signal_generator/0/frequency: 1000.0 [default: 1000.0]
/dual_iir/signal_generator/0/symmetry: 0.5 [default: 0.5]
/dual_iir/signal_generator/0/amplitude: 0.0 [default: 0.0]
/dual_iir/signal_generator/0/phase: 0.0 [default: 0.0]
/dual_iir/signal_generator/1/signal: "Cosine" [default: "Cosine"]
/dual_iir/signal_generator/1/frequency: 1000.0 [default: 1000.0]
/dual_iir/signal_generator/1/symmetry: 0.5 [default: 0.5]
/dual_iir/signal_generator/1/amplitude: 0.0 [default: 0.0]
/dual_iir/signal_generator/1/phase: 0.0 [default: 0.0]
/net/broker: "test" [default: "mqtt"]
/net/id: "04-91-62-d2-a8-6f" [default: "04-91-62-d2-a8-6f"]
/net/ip: "haha" [default: "0.0.0.0"]

> clear /net/ip
/net/ip cleared to default
Clear successful.

> list
/dual_iir/afe/0: "G1" [default: "G1"]
/dual_iir/afe/1: "G1" [default: "G1"]
/dual_iir/iir_ch/0/0: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0} [default: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0}]
/dual_iir/iir_ch/1/0: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0} [default: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0}]
/dual_iir/allow_hold: false [default: false]
/dual_iir/force_hold: false [default: false]
/dual_iir/telemetry_period: 10 [default: 10]
/dual_iir/stream_target: {"ip":[0,0,0,0],"port":0} [default: {"ip":[0,0,0,0],"port":0}]
/dual_iir/signal_generator/0/signal: "Cosine" [default: "Cosine"]
/dual_iir/signal_generator/0/frequency: 1000.0 [default: 1000.0]
/dual_iir/signal_generator/0/symmetry: 0.5 [default: 0.5]
/dual_iir/signal_generator/0/amplitude: 0.0 [default: 0.0]
/dual_iir/signal_generator/0/phase: 0.0 [default: 0.0]
/dual_iir/signal_generator/1/signal: "Cosine" [default: "Cosine"]
/dual_iir/signal_generator/1/frequency: 1000.0 [default: 1000.0]
/dual_iir/signal_generator/1/symmetry: 0.5 [default: 0.5]
/dual_iir/signal_generator/1/amplitude: 0.0 [default: 0.0]
/dual_iir/signal_generator/1/phase: 0.0 [default: 0.0]
/net/broker: "test" [default: "mqtt"]
/net/id: "04-91-62-d2-a8-6f" [default: "04-91-62-d2-a8-6f"]
/net/ip: "0.0.0.0" [default: "0.0.0.0"]

> clear /net/broker
/net/broker cleared to default
Clear successful.

> list
/dual_iir/afe/0: "G1" [default: "G1"]
/dual_iir/afe/1: "G1" [default: "G1"]
/dual_iir/iir_ch/0/0: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0} [default: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0}]
/dual_iir/iir_ch/1/0: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0} [default: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0}]
/dual_iir/allow_hold: false [default: false]
/dual_iir/force_hold: false [default: false]
/dual_iir/telemetry_period: 10 [default: 10]
/dual_iir/stream_target: {"ip":[0,0,0,0],"port":0} [default: {"ip":[0,0,0,0],"port":0}]
/dual_iir/signal_generator/0/signal: "Cosine" [default: "Cosine"]
/dual_iir/signal_generator/0/frequency: 1000.0 [default: 1000.0]
/dual_iir/signal_generator/0/symmetry: 0.5 [default: 0.5]
/dual_iir/signal_generator/0/amplitude: 0.0 [default: 0.0]
/dual_iir/signal_generator/0/phase: 0.0 [default: 0.0]
/dual_iir/signal_generator/1/signal: "Cosine" [default: "Cosine"]
/dual_iir/signal_generator/1/frequency: 1000.0 [default: 1000.0]
/dual_iir/signal_generator/1/symmetry: 0.5 [default: 0.5]
/dual_iir/signal_generator/1/amplitude: 0.0 [default: 0.0]
/dual_iir/signal_generator/1/phase: 0.0 [default: 0.0]
/net/broker: "mqtt" [default: "mqtt"]
/net/id: "04-91-62-d2-a8-6f" [default: "04-91-62-d2-a8-6f"]
/net/ip: "0.0.0.0" [default: "0.0.0.0"]

>
```