### PR TITLE
Omitting default value printing when values are default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
+name = "const-fnv1a-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
+
+[[package]]
 name = "cortex-m"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1061,7 @@ dependencies = [
 name = "serial-settings"
 version = "0.1.0"
 dependencies = [
+ "const-fnv1a-hash",
  "embedded-io",
  "heapless 0.8.0",
  "menu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,12 +152,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
-name = "const-fnv1a-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
-
-[[package]]
 name = "cortex-m"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -1061,11 +1055,11 @@ dependencies = [
 name = "serial-settings"
 version = "0.1.0"
 dependencies = [
- "const-fnv1a-hash",
  "embedded-io",
  "heapless 0.8.0",
  "menu",
  "miniconf",
+ "yafnv",
 ]
 
 [[package]]
@@ -1407,4 +1401,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "yafnv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f6944df20b02a525b3cb607bcd90b43b6ef77c8943958781190847a052b70"
+dependencies = [
+ "num-traits",
 ]

--- a/serial-settings/Cargo.toml
+++ b/serial-settings/Cargo.toml
@@ -10,4 +10,4 @@ miniconf = "0.9"
 menu = {version = "0.4", features = ["echo"]}
 heapless = "0.8"
 embedded-io = "0.6"
-const-fnv1a-hash = "1"
+yafnv = "0.1"

--- a/serial-settings/Cargo.toml
+++ b/serial-settings/Cargo.toml
@@ -10,3 +10,4 @@ miniconf = "0.9"
 menu = {version = "0.4", features = ["echo"]}
 heapless = "0.8"
 embedded-io = "0.6"
+const-fnv1a-hash = "1"


### PR DESCRIPTION
Fixes #864 by checking if the current settings value and the default value are equivalent by comparing an FNV1A 64-bit hash of the serialized strings.

There's a small hash collision probability, but for our case here it is likely inconsequential because the user can always refer to source code.

```
/net/broker: "mqtt" [default]
/net/id: "04-91-62-d2-a8-6f" [default]
/net/ip: "0.0.0.0" [default]

> set /net/broker "test"
Settings saved. Reboot device (`platform reboot`) to apply.

> list
/dual_iir/afe/0: "G1" [default]
/dual_iir/afe/1: "G1" [default]
/dual_iir/iir_ch/0/0: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0} [default]
/dual_iir/iir_ch/1/0: {"ba":[1.0,0.0,0.0,0.0,0.0],"u":0.0,"min":-32767.0,"max":32767.0} [default]
/dual_iir/allow_hold: false [default]
/dual_iir/force_hold: false [default]
/dual_iir/telemetry_period: 10 [default]
/dual_iir/stream_target: {"ip":[0,0,0,0],"port":0} [default]
/dual_iir/signal_generator/0/signal: "Cosine" [default]
/dual_iir/signal_generator/0/frequency: 1000.0 [default]
/dual_iir/signal_generator/0/symmetry: 0.5 [default]
/dual_iir/signal_generator/0/amplitude: 0.0 [default]
/dual_iir/signal_generator/0/phase: 0.0 [default]
/dual_iir/signal_generator/1/signal: "Cosine" [default]
/dual_iir/signal_generator/1/frequency: 1000.0 [default]
/dual_iir/signal_generator/1/symmetry: 0.5 [default]
/dual_iir/signal_generator/1/amplitude: 0.0 [default]
/dual_iir/signal_generator/1/phase: 0.0 [default]
/net/broker: "test" [default: "mqtt"]
/net/id: "04-91-62-d2-a8-6f" [default]
/net/ip: "0.0.0.0" [default]
```