### PR TITLE
Updating `menu` version to combine context and interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,7 +552,10 @@ dependencies = [
 [[package]]
 name = "menu"
 version = "0.4.0"
-source = "git+https://github.com/rust-embedded-community/menu?rev=7ba884993fea57c3661d0f9d7c3cdca639a48701#7ba884993fea57c3661d0f9d7c3cdca639a48701"
+source = "git+https://github.com/rust-embedded-community/menu?branch=feature/borrowed-context#65af81bb990ea2afa1022dfbfd09d11ad3334eb9"
+dependencies = [
+ "embedded-io",
+]
 
 [[package]]
 name = "miniconf"

--- a/serial-settings/Cargo.toml
+++ b/serial-settings/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 miniconf = "0.9"
 
-menu = {git = "https://github.com/rust-embedded-community/menu", rev = "7ba884993fea57c3661d0f9d7c3cdca639a48701", features = ["echo"]}
+menu = {git = "https://github.com/rust-embedded-community/menu", branch = "feature/borrowed-context", features = ["echo"]}
 heapless = "0.8"
 embedded-io = "0.6"
 yafnv = "0.1"

--- a/serial-settings/src/interface.rs
+++ b/serial-settings/src/interface.rs
@@ -28,15 +28,19 @@ where
     }
 }
 
-impl<T> core::fmt::Write for BestEffortInterface<T>
+impl<T> embedded_io::Write for BestEffortInterface<T>
 where
     T: embedded_io::Write + embedded_io::WriteReady,
 {
-    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         if let Ok(true) = self.0.write_ready() {
-            self.0.write(s.as_bytes()).ok();
+            self.0.write(buf).ok();
         }
-        Ok(())
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.0.flush()
     }
 }
 

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -91,11 +91,8 @@ pub type SerialPort = usbd_serial::SerialPort<
     &'static mut setup::SerialBufferStore,
 >;
 
-pub type SerialTerminal<C, const Y: usize> = serial_settings::Runner<
-    'static,
-    crate::settings::SerialSettingsPlatform<C, Y>,
-    Y,
->;
+pub type SerialTerminal<C, const Y: usize> =
+    serial_settings::Runner<'static, crate::settings::SettingsManager<C, Y>, Y>;
 
 pub enum HardwareVersion {
     Rev1_0,


### PR DESCRIPTION
This PR updates the version of `menu` used to have a single `context` that uses the embedded-io traits and is writable.

This PR was done to understand if the `context` and `interface` of menu could be combined.

 The main downside observed is that the `Settings` structure isn't carried around as a top-level resource, but is hidden behind a few layers of indirection because of the necessary lifetime borrow abstractions.