### PR TITLE
Updating sequential-storage, adding flash erase support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Booster
 * Panic information is now persisted after reboot and available via telemetry and the USB serial
 console.
+* Device operational settings can now be modified, stored and cleared from device flash using the
+  USB serial console. Run-time settings are unique to each application, but network settings are
+  unified for all applications (i.e. lockin, dual-iir, etc.)
 
 ### Changed
 * Broker and static IP/DHCP are no longer configured at compile time,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "embassy-futures"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f878075b9794c1e4ac788c95b728f26aa6366d32eeb10c7051389f898f7d067"
+
+[[package]]
 name = "embedded-dma"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +248,15 @@ name = "embedded-storage"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a21dea9854beb860f3062d10228ce9b976da520a73474aed3171ec276bc0c032"
+
+[[package]]
+name = "embedded-storage-async"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1763775e2323b7d5f0aa6090657f5e21cfa02ede71f5dc40eead06d64dcd15cc"
+dependencies = [
+ "embedded-storage",
+]
 
 [[package]]
 name = "embedded-time"
@@ -995,11 +1010,11 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sequential-storage"
-version = "0.6.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9294c2c7c725835fa69d5a144a29078159360bdc53593e5e977abf8d200f46"
+checksum = "6a4436f77b36958b8092ddea907a21d371dda9b5cd6fbe7036fba2a8479b8ace"
 dependencies = [
- "embedded-storage",
+ "embedded-storage-async",
 ]
 
 [[package]]
@@ -1121,9 +1136,11 @@ dependencies = [
  "built",
  "cortex-m",
  "cortex-m-rt",
+ "embassy-futures",
  "embedded-hal 0.2.7",
  "embedded-io",
  "embedded-storage",
+ "embedded-storage-async",
  "enum-iterator",
  "fugit",
  "heapless 0.7.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,8 +1011,8 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sequential-storage"
-version = "2.0.0"
-source = "git+https://github.com/quartiq/sequential-storage?branch=feature/remove-all-items#8fffc9137194e533f23c5009adacdc5ee450c4d7"
+version = "2.0.2"
+source = "git+https://github.com/quartiq/sequential-storage?branch=feature/remove-all-items#8826bda8364861df1f0c108b74f0ab34a9b4be54"
 dependencies = [
  "embedded-storage-async",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,7 +1138,8 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 [[package]]
 name = "sequential-storage"
 version = "2.0.2"
-source = "git+https://github.com/quartiq/sequential-storage?branch=feature/remove-all-items#8826bda8364861df1f0c108b74f0ab34a9b4be54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d25123e754473ed08bcc4e0ef61f0a733662872885e533ffdf03771119712fc"
 dependencies = [
  "embedded-storage-async",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,9 +1010,8 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sequential-storage"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a4436f77b36958b8092ddea907a21d371dda9b5cd6fbe7036fba2a8479b8ace"
+version = "2.0.0"
+source = "git+https://github.com/quartiq/sequential-storage?branch=feature/remove-all-items#8fffc9137194e533f23c5009adacdc5ee450c4d7"
 dependencies = [
  "embedded-storage-async",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,8 +542,9 @@ dependencies = [
 
 [[package]]
 name = "menu"
-version = "0.4.0"
-source = "git+https://github.com/rust-embedded-community/menu?rev=7ba884993fea57c3661d0f9d7c3cdca639a48701#7ba884993fea57c3661d0f9d7c3cdca639a48701"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce98110899b3b97775dd181d9088ebee9abcb6804bb7ead4e9450c1f5419562d"
 
 [[package]]
 name = "miniconf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = ["ad9959", "serial-settings"]
 
 [dependencies]
 panic-persist = { version = "0.3", features = ["utf8", "custom-panic-handler"] }
-sequential-storage = { git = "https://github.com/quartiq/sequential-storage", branch = "feature/remove-all-items" }
+sequential-storage = "2"
 embedded-io = "0.6"
 embedded-storage = "0.3"
 embedded-storage-async = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,10 @@ members = ["ad9959", "serial-settings"]
 
 [dependencies]
 panic-persist = { version = "0.3", features = ["utf8", "custom-panic-handler"] }
-sequential-storage = "0.6"
+sequential-storage = "1"
 embedded-io = "0.6"
 embedded-storage = "0.3"
+embedded-storage-async = "0.4"
 cortex-m = { version = "0.7.7", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rt = { version = "0.7", features = ["device"] }
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"] }
@@ -76,6 +77,7 @@ smoltcp-nal = { version = "0.4", features = ["shared-stack"], git = "https://git
 bbqueue = "0.5"
 postcard = "1"
 bit_field = "0.10.2"
+embassy-futures = { version = "0.1", default-features = false }
 
 [build-dependencies]
 built = { version = "0.7", features = ["git2"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ members = ["ad9959", "serial-settings"]
 
 [dependencies]
 panic-persist = { version = "0.3", features = ["utf8", "custom-panic-handler"] }
-sequential-storage = {git = "https://github.com/quartiq/sequential-storage", branch = "feature/remove-all-items"}
+sequential-storage = { git = "https://github.com/quartiq/sequential-storage", branch = "feature/remove-all-items" }
 embedded-io = "0.6"
 embedded-storage = "0.3"
 embedded-storage-async = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ members = ["ad9959", "serial-settings"]
 
 [dependencies]
 panic-persist = { version = "0.3", features = ["utf8", "custom-panic-handler"] }
-sequential-storage = "1"
+sequential-storage = {git = "https://github.com/quartiq/sequential-storage", branch = "feature/remove-all-items"}
 embedded-io = "0.6"
 embedded-storage = "0.3"
 embedded-storage-async = "0.4"

--- a/serial-settings/Cargo.toml
+++ b/serial-settings/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 miniconf = "0.9"
 
-menu = {git = "https://github.com/rust-embedded-community/menu", rev = "7ba884993fea57c3661d0f9d7c3cdca639a48701", features = ["echo"]}
+menu = {version = "0.5", features = ["echo"]}
 heapless = "0.8"
 embedded-io = "0.6"
 yafnv = "0.1"

--- a/serial-settings/src/lib.rs
+++ b/serial-settings/src/lib.rs
@@ -114,8 +114,8 @@ impl<'a, P: Platform<Y>, const Y: usize> Interface<'a, P, Y> {
         _menu: &menu::Menu<Self, P::Settings>,
         item: &menu::Item<Self, P::Settings>,
         args: &[&str],
-        _settings: &mut P::Settings,
         interface: &mut Self,
+        _settings: &mut P::Settings,
     ) {
         let key = menu::argument_finder(item, args, "cmd").unwrap().unwrap();
         interface.platform.cmd(key)
@@ -125,8 +125,8 @@ impl<'a, P: Platform<Y>, const Y: usize> Interface<'a, P, Y> {
         _menu: &menu::Menu<Self, P::Settings>,
         _item: &menu::Item<Self, P::Settings>,
         _args: &[&str],
-        settings: &mut P::Settings,
         interface: &mut Self,
+        settings: &mut P::Settings,
     ) {
         let mut defaults = settings.clone();
         defaults.reset();
@@ -202,8 +202,8 @@ impl<'a, P: Platform<Y>, const Y: usize> Interface<'a, P, Y> {
         _menu: &menu::Menu<Self, P::Settings>,
         item: &menu::Item<Self, P::Settings>,
         args: &[&str],
-        settings: &mut P::Settings,
         interface: &mut Self,
+        settings: &mut P::Settings,
     ) {
         let key = menu::argument_finder(item, args, "item").unwrap();
 
@@ -241,8 +241,8 @@ impl<'a, P: Platform<Y>, const Y: usize> Interface<'a, P, Y> {
         _menu: &menu::Menu<Self, P::Settings>,
         item: &menu::Item<Self, P::Settings>,
         args: &[&str],
-        settings: &mut P::Settings,
         interface: &mut Self,
+        settings: &mut P::Settings,
     ) {
         let key = menu::argument_finder(item, args, "item").unwrap().unwrap();
         match settings.get_json(key, interface.buffer) {
@@ -264,8 +264,8 @@ impl<'a, P: Platform<Y>, const Y: usize> Interface<'a, P, Y> {
         _menu: &menu::Menu<Self, P::Settings>,
         item: &menu::Item<Self, P::Settings>,
         args: &[&str],
-        settings: &mut P::Settings,
         interface: &mut Self,
+        settings: &mut P::Settings,
     ) {
         let key = menu::argument_finder(item, args, "item").unwrap().unwrap();
         let value =

--- a/serial-settings/src/lib.rs
+++ b/serial-settings/src/lib.rs
@@ -22,7 +22,7 @@
 //!   list
 //!   get <item>
 //!   set <item> <value>
-//!   clear
+//!   clear [ <item> ]
 //!   platform <cmd>
 //!   help [ <command> ]
 //!
@@ -97,7 +97,7 @@ pub trait Platform<const Y: usize>: Sized {
     /// # Arguments
     /// * `buffer` The element serialization buffer.
     /// * `key` The name of the setting to be cleared. If `None`, all settings are cleared.
-    fn clear(&mut self, _buffer: &mut [u8], _key: Option<&str>);
+    fn clear(&mut self, buffer: &mut [u8], key: Option<&str>);
 
     /// Return a mutable reference to the `Interface`.
     fn interface_mut(&mut self) -> &mut Self::Interface;

--- a/serial-settings/src/lib.rs
+++ b/serial-settings/src/lib.rs
@@ -22,6 +22,7 @@
 //!   list
 //!   get <item>
 //!   set <item> <value>
+//!   save
 //!   clear [ <item> ]
 //!   platform <cmd>
 //!   help [ <command> ]
@@ -82,6 +83,7 @@ pub trait Platform<const Y: usize>: Sized {
     fn save(
         &mut self,
         buffer: &mut [u8],
+        key: Option<&str>,
         settings: &Self::Settings,
     ) -> Result<(), Self::Error>;
 
@@ -260,6 +262,26 @@ impl<'a, P: Platform<Y>, const Y: usize> Interface<'a, P, Y> {
         .unwrap();
     }
 
+    fn handle_save(
+        _menu: &menu::Menu<Self, P::Settings>,
+        _item: &menu::Item<Self, P::Settings>,
+        _args: &[&str],
+        interface: &mut Self,
+        settings: &mut P::Settings,
+    ) {
+        match interface.platform.save(interface.buffer, None, settings) {
+            Ok(_) => {
+                writeln!(
+                        interface,
+                        "Settings saved. Reboot device (`platform reboot`) to apply."
+                    ).unwrap()
+            }
+            Err(e) => {
+                writeln!(interface, "Failed to save settings: {e:?}").unwrap()
+            }
+        }
+    }
+
     fn handle_set(
         _menu: &menu::Menu<Self, P::Settings>,
         item: &menu::Item<Self, P::Settings>,
@@ -277,7 +299,7 @@ impl<'a, P: Platform<Y>, const Y: usize> Interface<'a, P, Y> {
         {
             Ok(_) => {
                 interface.updated = true;
-                match interface.platform.save(interface.buffer, settings) {
+                match interface.platform.save(interface.buffer, Some(key), settings) {
                     Ok(_) => {
                         writeln!(
                                 interface,
@@ -333,6 +355,14 @@ impl<'a, P: Platform<Y>, const Y: usize> Interface<'a, P, Y> {
                             help: Some("Specifies the value to be written. Values must be JSON-encoded"),
                         },
                     ]
+                },
+            },
+            &menu::Item {
+                command: "save",
+                help: Some("Save all current settings to the device."),
+                item_type: menu::ItemType::Callback {
+                    function: Self::handle_save,
+                    parameters: &[],
                 },
             },
             &menu::Item {

--- a/serial-settings/src/lib.rs
+++ b/serial-settings/src/lib.rs
@@ -97,7 +97,7 @@ pub trait Platform<const Y: usize>: Sized {
     /// # Arguments
     /// * `buffer` The element serialization buffer.
     /// * `key` The name of the setting to be cleared. If `None`, all settings are cleared.
-    fn clear(&mut self, _buffer: &mut [u8], _key: Option<&str>) {}
+    fn clear(&mut self, _buffer: &mut [u8], _key: Option<&str>);
 
     /// Return a mutable reference to the `Interface`.
     fn interface_mut(&mut self) -> &mut Self::Interface;
@@ -205,7 +205,9 @@ impl<'a, P: Platform<Y>, const Y: usize> Interface<'a, P, Y> {
         settings: &mut P::Settings,
         interface: &mut Self,
     ) {
-        if let Some(key) = menu::argument_finder(item, args, "item").unwrap() {
+        let key = menu::argument_finder(item, args, "item").unwrap();
+
+        if let Some(key) = key {
             let mut defaults = settings.clone();
             defaults.reset();
 
@@ -224,16 +226,15 @@ impl<'a, P: Platform<Y>, const Y: usize> Interface<'a, P, Y> {
                 return;
             }
 
-            interface.platform.clear(interface.buffer, Some(key));
-
             interface.updated = true;
             writeln!(interface, "{key} cleared to default").unwrap();
         } else {
             settings.reset();
-            interface.platform.clear(interface.buffer, None);
             interface.updated = true;
             writeln!(interface, "All settings cleared").unwrap();
         }
+
+        interface.platform.clear(interface.buffer, key);
     }
 
     fn handle_get(

--- a/src/hardware/flash.rs
+++ b/src/hardware/flash.rs
@@ -84,7 +84,3 @@ impl embedded_storage_async::nor_flash::NorFlash for Flash {
         bank.write(offset, bytes)
     }
 }
-
-// Note: While this is supported, multiple writes to the same word can trigger ECC errors due to
-// incorrect writes.
-impl embedded_storage_async::nor_flash::MultiwriteNorFlash for Flash {}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -153,19 +153,23 @@ impl<'a> sequential_storage::map::Value<'a> for SettingsItem {
         &self,
         buffer: &mut [u8],
     ) -> Result<usize, sequential_storage::map::SerializationError> {
-        Ok(postcard::to_slice(self, buffer)
-            .map_err(|_| {
-                sequential_storage::map::SerializationError::BufferTooSmall
-            })?
-            .len())
+        if buffer.len() < self.0.len() {
+            return Err(
+                sequential_storage::map::SerializationError::BufferTooSmall,
+            );
+        }
+
+        buffer[..self.0.len()].copy_from_slice(&self.0);
+        Ok(self.0.len())
     }
 
     fn deserialize_from(
         buffer: &'a [u8],
     ) -> Result<Self, sequential_storage::map::SerializationError> {
-        postcard::from_bytes(buffer).map_err(|_| {
+        let vec = Vec::from_slice(buffer).map_err(|_| {
             sequential_storage::map::SerializationError::BufferTooSmall
-        })
+        })?;
+        Ok(Self(vec))
     }
 }
 


### PR DESCRIPTION
Fixes #861 by updating `clear <setting>` to actually erase the requested setting from flash memory instead of overwriting it with the current default value.

This PR also updates to `sequential-storage` v1.0 by using embassy-futures to complete the async operations in a blocking manner. This shouldn't matter at all because the underlying impl is blocking anyways. However, the version bump may cause users to lose their flash settings.

To test this, I cleared flash settings and rebooted the device. I then reprogrammed it with a new default broker of "mqtt2" and verified that the device used the new default of mqtt2 after reprogramming, which indicated that nothing was loaded from flash.