### PR TITLE
Feature/serial settings save individual values

### DIFF
--- a/serial-settings/src/lib.rs
+++ b/serial-settings/src/lib.rs
@@ -197,7 +197,8 @@ impl<'a, P: Platform<Y>, const Y: usize> Interface<'a, P, Y> {
         interface: &mut Self,
         settings: &mut P::Settings,
     ) {
-        if let Some(key) = menu::argument_finder(item, args, "item").unwrap() {
+        let maybe_key = menu::argument_finder(item, args, "item").unwrap();
+        if let Some(key) = maybe_key {
             let mut defaults = settings.clone();
             defaults.reset();
 
@@ -224,7 +225,7 @@ impl<'a, P: Platform<Y>, const Y: usize> Interface<'a, P, Y> {
             writeln!(interface, "All settings cleared").unwrap();
         }
 
-        match interface.platform.save(interface.buffer, settings) {
+        match interface.platform.save(interface.buffer, maybe_key, settings) {
             Ok(_) => {
                 writeln!(interface, "Settings saved. You may need to reboot for the settings to be applied")
             }

--- a/serial-settings/src/lib.rs
+++ b/serial-settings/src/lib.rs
@@ -226,7 +226,7 @@ impl<'a, P: Platform<Y>, const Y: usize> Interface<'a, P, Y> {
 
         match interface.platform.save(interface.buffer, settings) {
             Ok(_) => {
-                writeln!(interface, "Settings saved. Reboot device (`platform reboot`) to apply.")
+                writeln!(interface, "Settings saved. You may need to reboot for the settings to be applied")
             }
             Err(e) => {
                 writeln!(interface, "Failed to clear settings: {e:?}")
@@ -268,7 +268,7 @@ impl<'a, P: Platform<Y>, const Y: usize> Interface<'a, P, Y> {
         match interface.platform.save(interface.buffer, None, settings) {
             Ok(_) => writeln!(
                 interface,
-                "Settings saved. Reboot device (`platform reboot`) to apply."
+                "Settings saved. You may need to reboot for the settings to be applied"
             )
             .unwrap(),
             Err(e) => {
@@ -289,7 +289,6 @@ impl<'a, P: Platform<Y>, const Y: usize> Interface<'a, P, Y> {
             menu::argument_finder(item, args, "value").unwrap().unwrap();
 
         // Now, write the new value into memory.
-        // TODO: Validate it first?
         match settings.set_json(key, value.as_bytes())
         {
             Ok(_) => {
@@ -298,7 +297,7 @@ impl<'a, P: Platform<Y>, const Y: usize> Interface<'a, P, Y> {
                     Ok(_) => {
                         writeln!(
                                 interface,
-                                "Settings saved. Reboot device (`platform reboot`) to apply."
+                                "Settings saved. You may need to reboot for the settings to be applied"
                             )
                     }
                     Err(e) => {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -171,20 +171,12 @@ where
         settings: &Self::Settings,
     ) -> Result<(), Self::Error> {
         let mut save_setting = |path| -> Result<(), Self::Error> {
-            let path = SettingsKey(path);
-            let mut data = heapless::Vec::new();
-            data.resize(data.capacity(), 0).unwrap();
-
-            let mut serializer = postcard::Serializer {
-                output: postcard::ser_flavors::Slice::new(&mut data),
+            let mut item = SettingsItem {
+                path,
+                ..Default::default()
             };
 
-            if let Err(e) = settings
-                .serialize_by_key(path.0.split('/').skip(1), &mut serializer)
-            {
-                log::warn!("Failed to save `{}` to flash: {e:?}", path.0);
-                return Ok(());
-            }
+            item.data.resize(item.data.capacity(), 0).unwrap();
 
             let flavor = postcard::ser_flavors::Slice::new(&mut item.data);
 
@@ -196,7 +188,7 @@ where
                         "Failed to save `{}` to flash: {e:?}",
                         item.path
                     );
-                    continue;
+                    return Ok(());
                 }
                 Ok(slice) => slice.len(),
             };


### PR DESCRIPTION
This updates it so `set` doesn't save every setting, but rather just the setting you just modified.

It also fixes some of the user feedback

@jordens Do we want Stabilizer to always save-on-set? This might be a poor experience if users are experimenting with runtime settings and want to go back to "before I messed everything up".