### PR TITLE
Expose the serial-settings platform member

### DIFF
--- a/serial-settings/src/lib.rs
+++ b/serial-settings/src/lib.rs
@@ -435,6 +435,14 @@ impl<'a, P: Platform<Y>, const Y: usize> Runner<'a, P, Y> {
         self.0.interface.platform.interface_mut()
     }
 
+    pub fn platform_mut(&mut self) -> &mut P {
+        &mut self.0.interface.platform
+    }
+
+    pub fn platform(&mut self) -> &P {
+        &self.0.interface.platform
+    }
+
     /// Must be called periodically to process user input.
     ///
     /// # Returns


### PR DESCRIPTION
THis is needed if you store any state in `Platform` and need to access it outside of the serial settings API. I'll likely need to do this to facilitate some kind of messaging mechanism to inform Booster EEPROM to save settings once a USB `save` command is issued.