### PR TITLE
Increasing HITL timeout interval to 1h

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: HITL Run Status
           ref: ${{ github.event.pull_request.head.sha }}
+          # The HITL can be backlogged by multiple queues, where each takes ~5 minutes to complete.
+          timeoutSeconds: 3600
 
       - name: "Check HITL Status"
         if: steps.status.outputs.conclusion != 'success'


### PR DESCRIPTION
This PR fixes an issue where enqueuing multiple PRs to be merged will often fail because the HITL will time out waiting for the job to be scheduled.

This PR bumps the checker to wait up to 1 hour for HITL runs to complete.